### PR TITLE
feat(components/atom/tag): Set cursor to default on hover

### DIFF
--- a/components/atom/tag/src/index.scss
+++ b/components/atom/tag/src/index.scss
@@ -30,6 +30,7 @@ $base-class: '.sui-AtomTag';
   border: $bd-atom-tag;
   border-radius: ceil($h-atom-tag-m * 0.5);
   box-sizing: border-box;
+  cursor: default;
   display: inline-flex;
   font-size: $fz-s;
   height: $h-atom-tag-m;


### PR DESCRIPTION
## atom/tag
**TASK**: #1772


### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Description, Motivation and Context
The cursor changed to text when hovering on a tag instead of people the default one.

### Screenshots - Animations

**Before:**
![before-tag](https://user-images.githubusercontent.com/30704597/136393241-90cc40bc-33bc-45df-b82a-0427da91d779.gif)

----

**After:**
![after-tag](https://user-images.githubusercontent.com/30704597/136393200-4051704c-0f58-4837-81e1-0b3ddbbac220.gif)

