### PR TITLE
feat(components/molecule/autosuggest): Fix cursor on disabled autosug…

### DIFF
--- a/components/molecule/autosuggest/src/index.scss
+++ b/components/molecule/autosuggest/src/index.scss
@@ -39,7 +39,7 @@ $bdw-autosuggest-container: $bdw-s !default;
     &-container {
       align-items: center;
       border: $bdw-autosuggest-container solid transparent;
-      cursor: pointer;
+      cursor: default;
       display: flex;
       min-height: $h-atom-input--m;
     }


### PR DESCRIPTION
…gest list

## molecule/autosuggest
**TASK**: #1718


### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Description, Motivation and Context
Showing the default pointed when hovering over the disabled version of the Autosuggest instead of the cursor pointer.

### Screenshots - Animations


**Before:**

![135281509-592f00ad-7506-420f-a768-3d27e813e761](https://user-images.githubusercontent.com/30704597/136429791-fb069a81-a799-47b9-afed-6e6090ae8ebd.png)

**After:**

![Screen Recording 2021-10-07 at 18 51 40](https://user-images.githubusercontent.com/30704597/136429947-664c43fb-8969-4d17-b959-d4c98874f9b5.gif)