### PR TITLE
fix(components/atom/pinInput): Update styles on disabled state

### DIFF
--- a/components/atom/pinInput/src/PinInputField.scss
+++ b/components/atom/pinInput/src/PinInputField.scss
@@ -57,7 +57,8 @@ $pin-input-field-status: (
     width: 100%;
   }
   &:disabled {
-    cursor: not-allowed;
+    color: $c-gray-light-3;
+    cursor: default;
     pointer-events: all;
   }
 }


### PR DESCRIPTION
## atom/pinInput
**TASK**:  #1763


### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Description, Motivation and Context
The disabled state has a wrong color which makes it look like it's active



### Screenshots - Animations
**Before**
<img width="496" alt="Screenshot 2021-10-07 at 19 32 02" src="https://user-images.githubusercontent.com/30704597/136435346-28f3661f-0829-4d1c-b408-2aa66c10f342.png">

----

**After:**
<img width="468" alt="Screenshot 2021-10-07 at 19 30 28" src="https://user-images.githubusercontent.com/30704597/136435368-35ade305-5cbb-4d9c-8c11-9eea8a3834f4.png">

