### PR TITLE
fix(components/atom/progressBar): fix bdrs

### DIFF
--- a/components/atom/progressBar/src/LineProgressBar/index.scss
+++ b/components/atom/progressBar/src/LineProgressBar/index.scss
@@ -11,7 +11,7 @@ $bd-line-progress-container: $bdw-s solid $bc-progress-bar !default;
 // these two values below are deprecated, keeping for retro-compatibility
 $br-progress-container: $bdrs-base !default;
 $br-progress-bar: $bdrs-base !default;
-// this component uses $bdrs for border radius 
+// this component uses $bdrs for border radius
 $bdrs-progress-bar: $br-progress-bar !default;
 $bdrs-progress-container: $br-progress-container !default;
 $h-progress-bar: $m-base !default;

--- a/components/atom/progressBar/src/LineProgressBar/index.scss
+++ b/components/atom/progressBar/src/LineProgressBar/index.scss
@@ -8,8 +8,12 @@ $trsdu-progress-bar: 500ms !default;
 $trstf-progress-bar: linear !default;
 
 $bd-line-progress-container: $bdw-s solid $bc-progress-bar !default;
-$br-progress-container: $bdrs-l !default;
-$br-progress-bar: $bdrs-l !default;
+// these two values below are deprecated, keeping for retro-compatibility
+$br-progress-container: $bdrs-base !default;
+$br-progress-bar: $bdrs-base !default;
+// this component uses $bdrs for border radius 
+$bdrs-progress-bar: $br-progress-bar !default;
+$bdrs-progress-container: $br-progress-container !default;
 $h-progress-bar: $m-base !default;
 
 .sui-AtomLineProgressBarV2 {
@@ -30,14 +34,14 @@ $h-progress-bar: $m-base !default;
   &-container {
     background: $bg-progress-bar;
     border: $bd-line-progress-container;
-    border-radius: $br-progress-container;
+    border-radius: $bdrs-progress-container;
     height: $h-progress-bar; /* Can be anything */
     position: relative;
   }
 
   &-bar {
     background-color: $c-progress-bar-fill;
-    border-radius: $br-progress-bar;
+    border-radius: $bdrs-progress-bar;
     display: block;
     height: 100%;
     overflow: hidden;


### PR DESCRIPTION
ISSUES CLOSED: #1770

## atom/progressBar
The border radius of container and line are wrong


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
The border radius of container and line are wrong

![135668379-c27ee845-938d-4729-b73d-46b87a8a1649](https://user-images.githubusercontent.com/23620759/136601955-32a42ef5-20ff-4dce-be50-9ed1af45e5f8.png)

Both elements should have a fully rounded shape

![135668367-b4506211-1f98-4739-b8e0-dda9647eadba](https://user-images.githubusercontent.com/23620759/136601975-2e4f0942-9260-436d-b070-5d219fb4d95d.png)

