### PR TITLE
Fix disabled state autosuggest

### DIFF
--- a/components/atom/tag/src/Standard.js
+++ b/components/atom/tag/src/Standard.js
@@ -1,12 +1,21 @@
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 
-const StandardTag = ({className, closeIcon, icon, label, onClose, value}) => {
+const StandardTag = ({
+  className,
+  closeIcon,
+  icon,
+  label,
+  onClose,
+  value,
+  disabled
+}) => {
   const classNames = cx(className, closeIcon && 'sui-AtomTag-hasClose')
-
   const handleClick = ev => {
-    onClose(ev, {value, label})
-    ev.stopPropagation()
+    if (!disabled) {
+      onClose(ev, {value, label})
+      ev.stopPropagation()
+    }
   }
 
   return (
@@ -15,7 +24,7 @@ const StandardTag = ({className, closeIcon, icon, label, onClose, value}) => {
       <span className="sui-AtomTag-label" title={label}>
         {label}
       </span>
-      {closeIcon && (
+      {closeIcon && !disabled && (
         <span className="sui-AtomTag-closeable" onClick={handleClick}>
           <span className="sui-AtomTag-closeableIcon sui-AtomTag-secondary-icon">
             {closeIcon}
@@ -27,6 +36,7 @@ const StandardTag = ({className, closeIcon, icon, label, onClose, value}) => {
 }
 
 StandardTag.propTypes = {
+  disabled: PropTypes.bool,
   onClose: PropTypes.func,
   closeIcon: PropTypes.node,
   icon: PropTypes.node,

--- a/components/atom/tag/src/index.js
+++ b/components/atom/tag/src/index.js
@@ -13,7 +13,7 @@ import {
 import {filterKeys} from './helpers'
 
 const AtomTag = props => {
-  const {design, href, icon, onClick, responsive, size, type} = props
+  const {design, href, icon, onClick, responsive, size, type, disabled} = props
   const isActionable = onClick || href
   const classNames = cx(
     'sui-AtomTag',
@@ -21,7 +21,8 @@ const AtomTag = props => {
     design && `sui-AtomTag--${design}`,
     icon && 'sui-AtomTag-hasIcon',
     responsive && 'sui-AtomTag--responsive',
-    type && `sui-AtomTag--${type}`
+    type && `sui-AtomTag--${type}`,
+    disabled && 'sui-AtomTag--disabled'
   )
 
   /**
@@ -37,9 +38,17 @@ const AtomTag = props => {
   const getActionableProps = () => filterKeys(props, STANDARD_ONLY_PROPS)
 
   return isActionable ? (
-    <ActionableTag {...getActionableProps()} className={classNames} />
+    <ActionableTag
+      {...getActionableProps()}
+      disabled={disabled}
+      className={classNames}
+    />
   ) : (
-    <StandardTag {...getStandardProps()} className={classNames} />
+    <StandardTag
+      {...getStandardProps()}
+      disabled={disabled}
+      className={classNames}
+    />
   )
 }
 

--- a/components/molecule/autosuggest/src/components/MultipleSelection.js
+++ b/components/molecule/autosuggest/src/components/MultipleSelection.js
@@ -75,9 +75,11 @@ const MoleculeAutosuggestFieldMultiSelection = ({
   }
 
   const handleClear = ev => {
-    onChange(null, {value: ''})
-    onChangeTags(null, {tags: []})
-    onClear(ev)
+    if (!disabled) {
+      onChange(null, {value: ''})
+      onChangeTags(null, {tags: []})
+      onClear(ev)
+    }
   }
 
   return (
@@ -91,7 +93,7 @@ const MoleculeAutosuggestFieldMultiSelection = ({
         innerRefInput={moleculeInputRef}
         inputMode={inputMode}
         isOpen={isOpen}
-        isVisibleClear={tags.length}
+        isVisibleClear={!disabled && tags.length}
         noBorder
         onChange={handleChange}
         onChangeTags={handleChangeTags}

--- a/components/molecule/autosuggest/src/components/SingleSelection.js
+++ b/components/molecule/autosuggest/src/components/SingleSelection.js
@@ -47,8 +47,10 @@ const MoleculeAutosuggestSingleSelection = ({
   }
 
   const handleClear = ev => {
-    onChange(null, {value: ''})
-    onClear(ev)
+    if (!disabled) {
+      onChange(null, {value: ''})
+      onClear(ev)
+    }
   }
 
   const handleRightClick = ev => {

--- a/components/molecule/inputTags/src/index.js
+++ b/components/molecule/inputTags/src/index.js
@@ -100,6 +100,7 @@ const MoleculeInputTags = ({
             label={label}
             size={atomTagSizes.SMALL}
             responsive
+            disabled={disabled}
           />
         )
       })}


### PR DESCRIPTION
hide the close buttons of input and tag components

ISSUES CLOSED: #1792

## molecule/autosuggest
**TASK**: #1792


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
Fix the disabled state of the autosuggest by passing the disabled prop to the tag input component and hiding the close button of the autosuggest. Therefore this PR also touches the atom/tag component.

**Note**: by checking out the branch, you won't see a change in the tags, because the inputTag molecule import the atomTag from `@s-ui/react-atom-tag` instead of the locally changed `../../../atom/tag/src`. When you change the import you'll see the updated atomTag as well.

### Screenshots - Animations
![image](https://user-images.githubusercontent.com/1907152/136627389-1e8546a7-d4a5-4d41-a20d-5985fe300ef5.png)
