### PR TITLE
fix(components/molecule/checkboxField): feature/1733

### DIFF
--- a/components/molecule/checkboxField/src/index.scss
+++ b/components/molecule/checkboxField/src/index.scss
@@ -13,7 +13,12 @@ $c-molecule-checkbox-field: (
 
 .sui-MoleculeCheckboxField {
   input[type='checkbox'] {
-    margin: 0;
+    display: flex;
+    align-items: center;
+  }
+
+  span {
+    margin: 4px 0 0 4px;
   }
 
   .sui-AtomLabel {

--- a/components/molecule/checkboxField/src/index.scss
+++ b/components/molecule/checkboxField/src/index.scss
@@ -12,13 +12,15 @@ $c-molecule-checkbox-field: (
 ) !default;
 
 .sui-MoleculeCheckboxField {
-  input[type='checkbox'] {
+  .sui-AtomCheckbox {
+    width: $w-molecule-checkbox-field-input;
+    height: $h-molecule-checkbox-field-input;
     display: flex;
     align-items: center;
-  }
 
-  span {
-    margin: 4px 0 0 4px;
+    input[type='checkbox'] {
+      margin: 0;
+    }
   }
 
   .sui-AtomLabel {

--- a/components/molecule/checkboxField/src/index.scss
+++ b/components/molecule/checkboxField/src/index.scss
@@ -4,6 +4,8 @@
 
 $fw-molecule-checkbox-field-label: $fw-atom-label !default;
 $c-molecule-checkbox-field-label: $c-atom-label !default;
+$w-molecule-checkbox-field-input: $p-base * 2 !default;
+$h-molecule-checkbox-field-input: $p-base * 2 !default;
 
 $c-molecule-checkbox-field: (
   success: $c-success,


### PR DESCRIPTION
Alligned items added a margin-left

ISSUES CLOSED: 1733

## MOLECULE/CHECKBOXFIELD
**TASK**: <!--- [jira TASK ID](jiraURL) -->


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
Centered the checkbox.
Centered the above line adding margin-left.

It solves the allignment problem


### Screenshots - Animations
![1733 sui](https://user-images.githubusercontent.com/20232667/136773567-8fce787d-7416-425f-bf00-b56865d383aa.png)

