### PR TITLE
fix(components/molecule/thumbnail): 1:1 ratio has wrong width

### DIFF
--- a/components/molecule/thumbnail/demo/index.js
+++ b/components/molecule/thumbnail/demo/index.js
@@ -1,21 +1,38 @@
 /* eslint-disable react/prop-types, no-unused-vars, no-console */
+import PropTypes from 'prop-types'
+import {
+  Article,
+  Cell,
+  Code,
+  Emphasis,
+  Grid,
+  H1,
+  H2,
+  H3,
+  Paragraph
+} from '@s-ui/documentation-library'
+import Spinner from '@s-ui/react-atom-spinner'
 
 import MoleculeThumbnail, {
   moleculeThumbnailSize,
   moleculeThumbnailRatio,
   moleculeThumbnailShape
-} from 'components/molecule/thumbnail/src'
+} from '../src'
 
-import Spinner from '@s-ui/react-atom-spinner'
+const Demo = ({children}) => {
+  return <div style={{width: '100%', padding: 20}}>{children}</div>
+}
 
-import './index.scss'
+Demo.propTypes = {
+  children: PropTypes.node
+}
 
-const ImageNotFoundIcon = () => {
-  return (
-    <svg width="40" height="40">
-      <path d="M6.458 33.333c-1.72 0-3.125-1.382-3.125-3.077v-16.41c0-1.694 1.404-3.077 3.125-3.077h5.209l-.88.477 2.357-3.661a2.073 2.073 0 0 1 1.752-.918h9.791c.636 0 1.245.3 1.667.82l2.813 3.692-.834-.41h5.209c1.72 0 3.125 1.383 3.125 3.077v16.41c0 1.695-1.404 3.077-3.125 3.077H6.458zm0-2.05h27.084a1.04 1.04 0 0 0 1.041-1.027v-16.41a1.04 1.04 0 0 0-1.041-1.025h-5.209c-.328 0-.636-.152-.833-.41l-2.793-3.668c-.014-.017-.03-.025-.02-.025h-9.791c-.027 0-.01-.009-.006-.015l-2.344 3.64a1.046 1.046 0 0 1-.88.478H6.459a1.04 1.04 0 0 0-1.041 1.025v16.41a1.04 1.04 0 0 0 1.041 1.026zM20 29.23c-4.602 0-8.333-3.674-8.333-8.205 0-4.532 3.73-8.205 8.333-8.205 4.602 0 8.333 3.673 8.333 8.205 0 4.531-3.73 8.205-8.333 8.205zm0-2.052c3.452 0 6.25-2.755 6.25-6.153 0-3.399-2.798-6.154-6.25-6.154s-6.25 2.755-6.25 6.154c0 3.398 2.798 6.153 6.25 6.153zm-3.939-4.812a4.049 4.049 0 0 1 .751-3.984L3.66 5.23A1.111 1.111 0 0 1 5.23 3.66L18.7 17.127c.409-.132.847-.204 1.301-.204.454 0 .892.072 1.301.204L34.77 3.66A1.111 1.111 0 1 1 36.34 5.23L23.188 18.384a4.049 4.049 0 0 1 .75 3.983L36.342 34.77a1.111 1.111 0 0 1-1.571 1.571L22.634 24.205a4.19 4.19 0 0 1-2.634.923 4.19 4.19 0 0 1-2.634-.923L5.23 36.34A1.111 1.111 0 0 1 3.66 34.77L16.06 22.367zm14.356-5.444c-.576 0-1.042-.46-1.042-1.026 0-.566.466-1.025 1.042-1.025h1.041c.576 0 1.042.459 1.042 1.025 0 .567-.466 1.026-1.042 1.026h-1.041z" />
-    </svg>
-  )
+const DemoWrapper = ({children}) => {
+  return <div style={{display: 'flex', flexWrap: 'wrap'}}>{children}</div>
+}
+
+DemoWrapper.propTypes = {
+  children: PropTypes.node
 }
 
 const IMAGES = {
@@ -26,341 +43,148 @@ const IMAGES = {
   BAD: 'https://pic__sum.pho__tos/50?image=980'
 }
 
-const defaultErrorText = 'Image not found'
-
-const BASE_CLASS_DEMO = 'DemoMoleculeThumbnail'
-const CLASS_DEMO_TABLE = `sui-StudioTable ${BASE_CLASS_DEMO}-table`
-const CLASS_DEMO_CELL = `${BASE_CLASS_DEMO}-cell`
-
-const Demo = () => {
+const ImageNotFoundIcon = () => {
   return (
-    <div className="sui-StudioPreview">
-      <div className="sui-StudioPreview-content sui-StudioDemo-preview">
-        <h1>Thumbnail</h1>
-        <h2>Basic examples</h2>
-        <table className={CLASS_DEMO_TABLE}>
-          <tbody>
-            <tr>
-              <td className={CLASS_DEMO_CELL}>
-                <h3>Link</h3>
-                <MoleculeThumbnail
-                  src={IMAGES.FINAL}
-                  alt="Some alt"
-                  href="https://someLink"
-                  target="_blank"
-                  spinner={<Spinner noBackground />}
-                  placeholder={IMAGES.PLACEHOLDER}
-                  size={moleculeThumbnailSize.MEDIUM}
-                />
-              </td>
-              <td className={CLASS_DEMO_CELL}>
-                <h3>No link</h3>
-                <MoleculeThumbnail
-                  src={IMAGES.FINAL}
-                  alt="Some alt"
-                  target="_blank"
-                  spinner={<Spinner noBackground />}
-                  placeholder={IMAGES.PLACEHOLDER}
-                  size={moleculeThumbnailSize.MEDIUM}
-                />
-              </td>
-              <td className={CLASS_DEMO_CELL}>
-                <h3>Caption</h3>
-                <MoleculeThumbnail
-                  src={IMAGES.FINAL}
-                  alt="Some alt"
-                  captionText="Show!"
-                  spinner={<Spinner noBackground />}
-                  placeholder={IMAGES.PLACEHOLDER}
-                  size={moleculeThumbnailSize.MEDIUM}
-                />
-              </td>
-              <td className={CLASS_DEMO_CELL}>
-                <h3>Circled</h3>
-                <MoleculeThumbnail
-                  src={IMAGES.FINAL}
-                  alt="Some alt"
-                  href="https://someLink"
-                  target="_blank"
-                  captionText="Show!"
-                  spinner={<Spinner noBackground />}
-                  placeholder={IMAGES.PLACEHOLDER}
-                  shape={moleculeThumbnailShape.CIRCLED}
-                  size={moleculeThumbnailSize.MEDIUM}
-                />
-              </td>
-            </tr>
-          </tbody>
-        </table>
-
-        <h2>Squared & Ratio 1:1</h2>
-        <table className={CLASS_DEMO_TABLE}>
-          <tbody>
-            <tr>
-              <td className={CLASS_DEMO_CELL}>
-                <h3>Large</h3>
-                <MoleculeThumbnail
-                  src={IMAGES.FINAL}
-                  alt="Some alt"
-                  href="https://someLink"
-                  target="_blank"
-                  captionText="Show!"
-                  spinner={<Spinner noBackground />}
-                  placeholder={IMAGES.PLACEHOLDER}
-                  size={moleculeThumbnailSize.LARGE}
-                />
-              </td>
-              <td className={CLASS_DEMO_CELL}>
-                <h3>Medium</h3>
-                <MoleculeThumbnail
-                  src={IMAGES.FINAL}
-                  alt="Some alt"
-                  href="https://someLink"
-                  target="_blank"
-                  captionText="Show!"
-                  spinner={<Spinner noBackground />}
-                  placeholder={IMAGES.PLACEHOLDER}
-                  size={moleculeThumbnailSize.MEDIUM}
-                />
-              </td>
-              <td className={CLASS_DEMO_CELL}>
-                <h3>Small</h3>
-                <MoleculeThumbnail
-                  src={IMAGES.FINAL}
-                  alt="Some alt"
-                  href="https://someLink"
-                  target="_blank"
-                  captionText="Show!"
-                  spinner={<Spinner noBackground />}
-                  placeholder={IMAGES.PLACEHOLDER}
-                  size={moleculeThumbnailSize.SMALL}
-                />
-              </td>
-              <td className={CLASS_DEMO_CELL}>
-                <h3>Xsmall</h3>
-                <MoleculeThumbnail
-                  src={IMAGES.FINAL}
-                  alt="Some alt"
-                  href="https://someLink"
-                  target="_blank"
-                  captionText="Show!"
-                  spinner={<Spinner noBackground />}
-                  placeholder={IMAGES.PLACEHOLDER}
-                  size={moleculeThumbnailSize.XSMALL}
-                />
-              </td>
-            </tr>
-          </tbody>
-        </table>
-
-        <h2>Squared & Ratio 4:3</h2>
-        <table className={CLASS_DEMO_TABLE}>
-          <tbody>
-            <tr>
-              <td className={CLASS_DEMO_CELL}>
-                <h3>Large</h3>
-                <MoleculeThumbnail
-                  src={IMAGES.FINAL}
-                  alt="Some alt"
-                  href="https://someLink"
-                  target="_blank"
-                  captionText="Show!"
-                  spinner={<Spinner noBackground />}
-                  placeholder={IMAGES.PLACEHOLDER}
-                  size={moleculeThumbnailSize.LARGE}
-                  ratio={moleculeThumbnailRatio['4:3']}
-                />
-              </td>
-              <td className={CLASS_DEMO_CELL}>
-                <h3>Medium</h3>
-                <MoleculeThumbnail
-                  src={IMAGES.FINAL}
-                  alt="Some alt"
-                  href="https://someLink"
-                  target="_blank"
-                  captionText="Show!"
-                  spinner={<Spinner noBackground />}
-                  placeholder={IMAGES.PLACEHOLDER}
-                  size={moleculeThumbnailSize.MEDIUM}
-                  ratio={moleculeThumbnailRatio['4:3']}
-                />
-              </td>
-              <td className={CLASS_DEMO_CELL}>
-                <h3>Small</h3>
-                <MoleculeThumbnail
-                  src={IMAGES.FINAL}
-                  alt="Some alt"
-                  href="https://someLink"
-                  target="_blank"
-                  captionText="Show!"
-                  spinner={<Spinner noBackground />}
-                  placeholder={IMAGES.PLACEHOLDER}
-                  size={moleculeThumbnailSize.SMALL}
-                  ratio={moleculeThumbnailRatio['4:3']}
-                />
-              </td>
-              <td className={CLASS_DEMO_CELL}>
-                <h3>Xsmall</h3>
-                <MoleculeThumbnail
-                  src={IMAGES.FINAL}
-                  alt="Some alt"
-                  href="https://someLink"
-                  target="_blank"
-                  captionText="Show!"
-                  spinner={<Spinner noBackground />}
-                  placeholder={IMAGES.PLACEHOLDER}
-                  size={moleculeThumbnailSize.XSMALL}
-                  ratio={moleculeThumbnailRatio['4:3']}
-                />
-              </td>
-            </tr>
-          </tbody>
-        </table>
-
-        <h2>Squared & Ratio 16:9</h2>
-        <table className={CLASS_DEMO_TABLE}>
-          <tbody>
-            <tr>
-              <td className={CLASS_DEMO_CELL}>
-                <h3>Large</h3>
-                <MoleculeThumbnail
-                  src={IMAGES.FINAL}
-                  alt="Some alt"
-                  href="https://someLink"
-                  target="_blank"
-                  captionText="Show!"
-                  spinner={<Spinner noBackground />}
-                  placeholder={IMAGES.PLACEHOLDER}
-                  size={moleculeThumbnailSize.LARGE}
-                  ratio={moleculeThumbnailRatio['16:9']}
-                />
-              </td>
-              <td className={CLASS_DEMO_CELL}>
-                <h3>Medium</h3>
-                <MoleculeThumbnail
-                  src={IMAGES.FINAL}
-                  alt="Some alt"
-                  href="https://someLink"
-                  target="_blank"
-                  captionText="Show!"
-                  spinner={<Spinner noBackground />}
-                  placeholder={IMAGES.PLACEHOLDER}
-                  size={moleculeThumbnailSize.MEDIUM}
-                  ratio={moleculeThumbnailRatio['16:9']}
-                />
-              </td>
-              <td className={CLASS_DEMO_CELL}>
-                <h3>Small</h3>
-                <MoleculeThumbnail
-                  src={IMAGES.FINAL}
-                  alt="Some alt"
-                  href="https://someLink"
-                  target="_blank"
-                  captionText="Show!"
-                  spinner={<Spinner noBackground />}
-                  placeholder={IMAGES.PLACEHOLDER}
-                  size={moleculeThumbnailSize.SMALL}
-                  ratio={moleculeThumbnailRatio['16:9']}
-                />
-              </td>
-              <td className={CLASS_DEMO_CELL}>
-                <h3>Xsmall</h3>
-                <MoleculeThumbnail
-                  src={IMAGES.FINAL}
-                  alt="Some alt"
-                  href="https://someLink"
-                  target="_blank"
-                  captionText="Show!"
-                  spinner={<Spinner noBackground />}
-                  placeholder={IMAGES.PLACEHOLDER}
-                  size={moleculeThumbnailSize.XSMALL}
-                  ratio={moleculeThumbnailRatio['16:9']}
-                />
-              </td>
-            </tr>
-          </tbody>
-        </table>
-
-        <h2>Circled & ratio 1:1</h2>
-        <table className={CLASS_DEMO_TABLE}>
-          <tbody>
-            <tr>
-              <td className={CLASS_DEMO_CELL}>
-                <h3>Large</h3>
-                <MoleculeThumbnail
-                  src={IMAGES.FINAL}
-                  alt="Some alt"
-                  href="https://someLink"
-                  target="_blank"
-                  captionText="Show!"
-                  spinner={<Spinner noBackground />}
-                  placeholder={IMAGES.PLACEHOLDER}
-                  shape={moleculeThumbnailShape.CIRCLED}
-                  size={moleculeThumbnailSize.LARGE}
-                />
-              </td>
-              <td className={CLASS_DEMO_CELL}>
-                <h3>Medium</h3>
-                <MoleculeThumbnail
-                  src={IMAGES.FINAL}
-                  alt="Some alt"
-                  href="https://someLink"
-                  target="_blank"
-                  captionText="Show!"
-                  spinner={<Spinner noBackground />}
-                  placeholder={IMAGES.PLACEHOLDER}
-                  shape={moleculeThumbnailShape.CIRCLED}
-                  size={moleculeThumbnailSize.MEDIUM}
-                />
-              </td>
-              <td className={CLASS_DEMO_CELL}>
-                <h3>Small</h3>
-                <MoleculeThumbnail
-                  src={IMAGES.FINAL}
-                  alt="Some alt"
-                  href="https://someLink"
-                  target="_blank"
-                  captionText="Show!"
-                  spinner={<Spinner noBackground />}
-                  placeholder={IMAGES.PLACEHOLDER}
-                  shape={moleculeThumbnailShape.CIRCLED}
-                  size={moleculeThumbnailSize.SMALL}
-                />
-              </td>
-              <td className={CLASS_DEMO_CELL}>
-                <h3>Xsmall</h3>
-                <MoleculeThumbnail
-                  src={IMAGES.FINAL}
-                  alt="Some alt"
-                  href="https://someLink"
-                  target="_blank"
-                  captionText="Show!"
-                  spinner={<Spinner noBackground />}
-                  placeholder={IMAGES.PLACEHOLDER}
-                  shape={moleculeThumbnailShape.CIRCLED}
-                  size={moleculeThumbnailSize.XSMALL}
-                />
-              </td>
-            </tr>
-          </tbody>
-        </table>
-
-        <h2>Fallback example</h2>
-        <div style={{width: '20%'}}>
-          <MoleculeThumbnail
-            src={IMAGES.BAD}
-            alt="Some alt"
-            captionText="Show!"
-            spinner={<Spinner noBackground />}
-            placeholder={IMAGES.PLACEHOLDER}
-            errorIcon={<ImageNotFoundIcon />}
-            errorText={defaultErrorText}
-            size={moleculeThumbnailSize.LARGE}
-          />
-        </div>
-      </div>
-    </div>
+    <svg width="40" height="40">
+      <path d="M6.458 33.333c-1.72 0-3.125-1.382-3.125-3.077v-16.41c0-1.694 1.404-3.077 3.125-3.077h5.209l-.88.477 2.357-3.661a2.073 2.073 0 0 1 1.752-.918h9.791c.636 0 1.245.3 1.667.82l2.813 3.692-.834-.41h5.209c1.72 0 3.125 1.383 3.125 3.077v16.41c0 1.695-1.404 3.077-3.125 3.077H6.458zm0-2.05h27.084a1.04 1.04 0 0 0 1.041-1.027v-16.41a1.04 1.04 0 0 0-1.041-1.025h-5.209c-.328 0-.636-.152-.833-.41l-2.793-3.668c-.014-.017-.03-.025-.02-.025h-9.791c-.027 0-.01-.009-.006-.015l-2.344 3.64a1.046 1.046 0 0 1-.88.478H6.459a1.04 1.04 0 0 0-1.041 1.025v16.41a1.04 1.04 0 0 0 1.041 1.026zM20 29.23c-4.602 0-8.333-3.674-8.333-8.205 0-4.532 3.73-8.205 8.333-8.205 4.602 0 8.333 3.673 8.333 8.205 0 4.531-3.73 8.205-8.333 8.205zm0-2.052c3.452 0 6.25-2.755 6.25-6.153 0-3.399-2.798-6.154-6.25-6.154s-6.25 2.755-6.25 6.154c0 3.398 2.798 6.153 6.25 6.153zm-3.939-4.812a4.049 4.049 0 0 1 .751-3.984L3.66 5.23A1.111 1.111 0 0 1 5.23 3.66L18.7 17.127c.409-.132.847-.204 1.301-.204.454 0 .892.072 1.301.204L34.77 3.66A1.111 1.111 0 1 1 36.34 5.23L23.188 18.384a4.049 4.049 0 0 1 .75 3.983L36.342 34.77a1.111 1.111 0 0 1-1.571 1.571L22.634 24.205a4.19 4.19 0 0 1-2.634.923 4.19 4.19 0 0 1-2.634-.923L5.23 36.34A1.111 1.111 0 0 1 3.66 34.77L16.06 22.367zm14.356-5.444c-.576 0-1.042-.46-1.042-1.026 0-.566.466-1.025 1.042-1.025h1.041c.576 0 1.042.459 1.042 1.025 0 .567-.466 1.026-1.042 1.026h-1.041z" />
+    </svg>
   )
 }
 
-export default Demo
+const defaultErrorText = 'Image not found'
+
+export default () => {
+  const renderSizes = (
+    ratio = moleculeThumbnailRatio['1:1'],
+    shape = moleculeThumbnailShape.SQUARED
+  ) => (
+    <Grid cols={4}>
+      {Object.keys(moleculeThumbnailSize).map((label, idx) => (
+        <Cell key={`render-sizes-${ratio}-${idx}`}>
+          <H3>{label.toLocaleLowerCase()}</H3>
+        </Cell>
+      ))}
+      {Object.keys(moleculeThumbnailSize).map((label, idx) => (
+        <Cell key={`render-sizes-${ratio}-${idx}`}>
+          <MoleculeThumbnail
+            src={IMAGES.FINAL}
+            alt="Some alt"
+            href="https://someLink"
+            target="_blank"
+            captionText="Show!"
+            spinner={<Spinner noBackground />}
+            placeholder={IMAGES.PLACEHOLDER}
+            size={label.toLocaleLowerCase()}
+            ratio={moleculeThumbnailRatio[ratio]}
+            shape={shape}
+          />
+        </Cell>
+      ))}
+    </Grid>
+  )
+
+  return (
+    <div>
+      <H1>Thumbnail</H1>
+      <Article>
+        <H2>Basic examples</H2>
+        <Grid cols={4}>
+          <Cell>
+            <H3>Link</H3>
+          </Cell>
+          <Cell>
+            <H3>No link</H3>
+          </Cell>
+          <Cell>
+            <H3>Caption</H3>
+          </Cell>
+          <Cell>
+            <H3>Circled</H3>
+          </Cell>
+          <Cell>
+            <MoleculeThumbnail
+              src={IMAGES.FINAL}
+              alt="Some alt"
+              href="https://someLink"
+              target="_blank"
+              spinner={<Spinner noBackground />}
+              placeholder={IMAGES.PLACEHOLDER}
+              size={moleculeThumbnailSize.MEDIUM}
+            />
+          </Cell>
+          <Cell>
+            <MoleculeThumbnail
+              src={IMAGES.FINAL}
+              alt="Some alt"
+              target="_blank"
+              spinner={<Spinner noBackground />}
+              placeholder={IMAGES.PLACEHOLDER}
+              size={moleculeThumbnailSize.MEDIUM}
+            />
+          </Cell>
+          <Cell>
+            <MoleculeThumbnail
+              src={IMAGES.FINAL}
+              alt="Some alt"
+              captionText="Show!"
+              spinner={<Spinner noBackground />}
+              placeholder={IMAGES.PLACEHOLDER}
+              size={moleculeThumbnailSize.MEDIUM}
+            />
+          </Cell>
+          <Cell>
+            <MoleculeThumbnail
+              src={IMAGES.FINAL}
+              alt="Some alt"
+              href="https://someLink"
+              target="_blank"
+              captionText="Show!"
+              spinner={<Spinner noBackground />}
+              placeholder={IMAGES.PLACEHOLDER}
+              shape={moleculeThumbnailShape.CIRCLED}
+              size={moleculeThumbnailSize.MEDIUM}
+            />
+          </Cell>
+        </Grid>
+      </Article>
+      <br />
+      <Article>
+        <H2>Squared & Ratio 1:1</H2>
+        {renderSizes()}
+      </Article>
+      <br />
+      <Article>
+        <H2>Squared & Ratio 4:3</H2>
+        {renderSizes(moleculeThumbnailRatio['4:3'])}
+      </Article>
+      <br />
+      <Article>
+        <H2>Squared & Ratio 16:9</H2>
+        {renderSizes(moleculeThumbnailRatio['16:9'])}
+      </Article>
+
+      <br />
+      <Article>
+        <H2>Circled & ratio 1:1</H2>
+        {renderSizes(
+          moleculeThumbnailRatio['1:1'],
+          moleculeThumbnailShape.CIRCLED
+        )}
+      </Article>
+      <br />
+      <Article>
+        <H2>Fallback example</H2>
+        <MoleculeThumbnail
+          src={IMAGES.BAD}
+          alt="Some alt"
+          captionText="Show!"
+          spinner={<Spinner noBackground />}
+          placeholder={IMAGES.PLACEHOLDER}
+          errorIcon={<ImageNotFoundIcon />}
+          errorText={defaultErrorText}
+          size={moleculeThumbnailSize.LARGE}
+        />
+      </Article>
+    </div>
+  )
+}

--- a/components/molecule/thumbnail/demo/index.js
+++ b/components/molecule/thumbnail/demo/index.js
@@ -86,105 +86,109 @@ export default () => {
   return (
     <div>
       <H1>Thumbnail</H1>
-      <Article>
-        <H2>Basic examples</H2>
-        <Grid cols={4}>
-          <Cell>
-            <H3>Link</H3>
-          </Cell>
-          <Cell>
-            <H3>No link</H3>
-          </Cell>
-          <Cell>
-            <H3>Caption</H3>
-          </Cell>
-          <Cell>
-            <H3>Circled</H3>
-          </Cell>
-          <Cell>
-            <MoleculeThumbnail
-              src={IMAGES.FINAL}
-              alt="Some alt"
-              href="https://someLink"
-              target="_blank"
-              spinner={<Spinner noBackground />}
-              placeholder={IMAGES.PLACEHOLDER}
-              size={moleculeThumbnailSize.MEDIUM}
-            />
-          </Cell>
-          <Cell>
-            <MoleculeThumbnail
-              src={IMAGES.FINAL}
-              alt="Some alt"
-              target="_blank"
-              spinner={<Spinner noBackground />}
-              placeholder={IMAGES.PLACEHOLDER}
-              size={moleculeThumbnailSize.MEDIUM}
-            />
-          </Cell>
-          <Cell>
-            <MoleculeThumbnail
-              src={IMAGES.FINAL}
-              alt="Some alt"
-              captionText="Show!"
-              spinner={<Spinner noBackground />}
-              placeholder={IMAGES.PLACEHOLDER}
-              size={moleculeThumbnailSize.MEDIUM}
-            />
-          </Cell>
-          <Cell>
-            <MoleculeThumbnail
-              src={IMAGES.FINAL}
-              alt="Some alt"
-              href="https://someLink"
-              target="_blank"
-              captionText="Show!"
-              spinner={<Spinner noBackground />}
-              placeholder={IMAGES.PLACEHOLDER}
-              shape={moleculeThumbnailShape.CIRCLED}
-              size={moleculeThumbnailSize.MEDIUM}
-            />
-          </Cell>
-        </Grid>
-      </Article>
-      <br />
-      <Article>
-        <H2>Squared & Ratio 1:1</H2>
-        {renderSizes()}
-      </Article>
-      <br />
-      <Article>
-        <H2>Squared & Ratio 4:3</H2>
-        {renderSizes(moleculeThumbnailRatio['4:3'])}
-      </Article>
-      <br />
-      <Article>
-        <H2>Squared & Ratio 16:9</H2>
-        {renderSizes(moleculeThumbnailRatio['16:9'])}
-      </Article>
+      <DemoWrapper>
+        <Demo>
+          <Article>
+            <H2>Basic examples</H2>
+            <Grid cols={4}>
+              <Cell>
+                <H3>Link</H3>
+              </Cell>
+              <Cell>
+                <H3>No link</H3>
+              </Cell>
+              <Cell>
+                <H3>Caption</H3>
+              </Cell>
+              <Cell>
+                <H3>Circled</H3>
+              </Cell>
+              <Cell>
+                <MoleculeThumbnail
+                  src={IMAGES.FINAL}
+                  alt="Some alt"
+                  href="https://someLink"
+                  target="_blank"
+                  spinner={<Spinner noBackground />}
+                  placeholder={IMAGES.PLACEHOLDER}
+                  size={moleculeThumbnailSize.MEDIUM}
+                />
+              </Cell>
+              <Cell>
+                <MoleculeThumbnail
+                  src={IMAGES.FINAL}
+                  alt="Some alt"
+                  target="_blank"
+                  spinner={<Spinner noBackground />}
+                  placeholder={IMAGES.PLACEHOLDER}
+                  size={moleculeThumbnailSize.MEDIUM}
+                />
+              </Cell>
+              <Cell>
+                <MoleculeThumbnail
+                  src={IMAGES.FINAL}
+                  alt="Some alt"
+                  captionText="Show!"
+                  spinner={<Spinner noBackground />}
+                  placeholder={IMAGES.PLACEHOLDER}
+                  size={moleculeThumbnailSize.MEDIUM}
+                />
+              </Cell>
+              <Cell>
+                <MoleculeThumbnail
+                  src={IMAGES.FINAL}
+                  alt="Some alt"
+                  href="https://someLink"
+                  target="_blank"
+                  captionText="Show!"
+                  spinner={<Spinner noBackground />}
+                  placeholder={IMAGES.PLACEHOLDER}
+                  shape={moleculeThumbnailShape.CIRCLED}
+                  size={moleculeThumbnailSize.MEDIUM}
+                />
+              </Cell>
+            </Grid>
+          </Article>
+          <br />
+          <Article>
+            <H2>Squared & Ratio 1:1</H2>
+            {renderSizes()}
+          </Article>
+          <br />
+          <Article>
+            <H2>Squared & Ratio 4:3</H2>
+            {renderSizes(moleculeThumbnailRatio['4:3'])}
+          </Article>
+          <br />
+          <Article>
+            <H2>Squared & Ratio 16:9</H2>
+            {renderSizes(moleculeThumbnailRatio['16:9'])}
+          </Article>
 
-      <br />
-      <Article>
-        <H2>Circled & ratio 1:1</H2>
-        {renderSizes(
-          moleculeThumbnailRatio['1:1'],
-          moleculeThumbnailShape.CIRCLED
-        )}
-      </Article>
-      <br />
-      <Article>
-        <H2>Fallback example</H2>
-        <MoleculeThumbnail
-          src={IMAGES.BAD}
-          alt="Some alt"
-          captionText="Show!"
-          spinner={<Spinner noBackground />}
-          placeholder={IMAGES.PLACEHOLDER}
-          errorIcon={<ImageNotFoundIcon />}
-          errorText={defaultErrorText}
-          size={moleculeThumbnailSize.LARGE}
-        />
-      </Article>
+          <br />
+          <Article>
+            <H2>Circled & ratio 1:1</H2>
+            {renderSizes(
+              moleculeThumbnailRatio['1:1'],
+              moleculeThumbnailShape.CIRCLED
+            )}
+          </Article>
+          <br />
+          <Article>
+            <H2>Fallback example</H2>
+            <MoleculeThumbnail
+              src={IMAGES.BAD}
+              alt="Some alt"
+              captionText="Show!"
+              spinner={<Spinner noBackground />}
+              placeholder={IMAGES.PLACEHOLDER}
+              errorIcon={<ImageNotFoundIcon />}
+              errorText={defaultErrorText}
+              size={moleculeThumbnailSize.LARGE}
+            />
+          </Article>
+        </Demo>
+      </DemoWrapper>
     </div>
   )
 }

--- a/components/molecule/thumbnail/demo/playground
+++ b/components/molecule/thumbnail/demo/playground
@@ -1,1 +1,0 @@
-return <p>This shouldn't be displayed</p>

--- a/components/molecule/thumbnail/src/index.js
+++ b/components/molecule/thumbnail/src/index.js
@@ -1,29 +1,15 @@
 import PropTypes from 'prop-types'
 import AtomImage from '@s-ui/react-atom-image'
 import cx from 'classnames'
-
-const BASE_CLASS = 'sui-MoleculeThumbnail'
-const CAPTION_CLASS = `${BASE_CLASS}-caption`
-const LINK_CLASS = `${BASE_CLASS}-link`
-const CONTAINER_IMAGE = `${BASE_CLASS}-containerImage`
-
-const SIZES = {
-  LARGE: 'large',
-  MEDIUM: 'medium',
-  SMALL: 'small',
-  XSMALL: 'xsmall'
-}
-
-const RATIOS = {
-  '1:1': '1-1',
-  '4:3': '4-3',
-  '16:9': '16-9'
-}
-
-const SHAPES = {
-  SQUARED: 'squared',
-  CIRCLED: 'circled'
-}
+import {
+  BASE_CLASS,
+  CAPTION_CLASS,
+  CONTAINER_IMAGE,
+  LINK_CLASS,
+  THUMBNAIL_RATIOS,
+  THUMBNAIL_SHAPES,
+  THUMBNAIL_SIZES
+} from './settings'
 
 const MoleculeThumbnail = props => {
   const {
@@ -112,31 +98,31 @@ MoleculeThumbnail.propTypes = {
   target: PropTypes.oneOf(['_self', '_blank', '_parent', '_top']),
 
   /** Define the size (LARGE, MEDIUM, SMALL or XSMALL) */
-  size: PropTypes.oneOf(Object.values(SIZES)),
+  size: PropTypes.oneOf(Object.values(THUMBNAIL_SIZES)),
 
   /** Define the shape (SQUARED or CIRCLED) */
-  shape: PropTypes.oneOf(Object.values(SHAPES)),
+  shape: PropTypes.oneOf(Object.values(THUMBNAIL_SHAPES)),
 
   /** Define the ratio ('1:1', '4:3', '16:9') */
-  ratio: PropTypes.oneOf(Object.values(RATIOS)),
+  ratio: PropTypes.oneOf(Object.values(THUMBNAIL_RATIOS)),
 
   /** Factory used to create navigation links */
   linkFactory: PropTypes.func
 }
 
 MoleculeThumbnail.defaultProps = {
-  target: '_blank',
-  size: SIZES.MEDIUM,
-  shape: SHAPES.SQUARED,
-  ratio: RATIOS['1:1'],
   // eslint-disable-next-line react/prop-types
-  linkFactory: ({children, ...rest} = {}) => <a {...rest}>{children}</a>
+  linkFactory: ({children, ...rest} = {}) => <a {...rest}>{children}</a>,
+  ratio: THUMBNAIL_RATIOS['1:1'],
+  shape: THUMBNAIL_SHAPES.SQUARED,
+  size: THUMBNAIL_SIZES.MEDIUM,
+  target: '_blank'
 }
 
 export default MoleculeThumbnail
 
 export {
-  SIZES as moleculeThumbnailSize,
-  RATIOS as moleculeThumbnailRatio,
-  SHAPES as moleculeThumbnailShape
+  THUMBNAIL_RATIOS as moleculeThumbnailRatio,
+  THUMBNAIL_SHAPES as moleculeThumbnailShape,
+  THUMBNAIL_SIZES as moleculeThumbnailSize
 }

--- a/components/molecule/thumbnail/src/index.scss
+++ b/components/molecule/thumbnail/src/index.scss
@@ -15,7 +15,6 @@ $bgc-molecule-thumbnail-caption: color-variation($c-gray-light, 3) !default;
 $c-molecule-thumbnail-caption: $c-primary !default;
 $fz-molecule-thumbnail-caption: $fz-s !default;
 $ta-molecule-thumbnail-caption: center !default;
-$w-molecule-thumbnail-caption: calc(100% - #{$p-m * 2} - #{$bdw-s * 2});
 $bd-molecule-thumbnail-container-image: 0 !default;
 
 $sizes-molecule-thumbnail: (
@@ -93,7 +92,6 @@ $ratios-molecule-thumbnail: (
     text-align: $ta-molecule-thumbnail-caption;
     text-overflow: ellipsis;
     white-space: nowrap;
-    width: $w-molecule-thumbnail-caption;
   }
 
   &-containerImage {

--- a/components/molecule/thumbnail/src/index.scss
+++ b/components/molecule/thumbnail/src/index.scss
@@ -126,6 +126,10 @@ $ratios-molecule-thumbnail: (
     @each $key-size, $size in $sizes-molecule-thumbnail {
       &--#{$key-size} {
         width: $size;
+
+        .sui-MoleculeThumbnail-containerImage--1-1 {
+          width: $size;
+        }
       }
 
       @each $key-ratio, $ratio in $ratios-molecule-thumbnail {

--- a/components/molecule/thumbnail/src/index.scss
+++ b/components/molecule/thumbnail/src/index.scss
@@ -9,12 +9,13 @@ $bd-molecule-thumbnail: $bdw-s solid transparent !default;
 $bdc-molecule-thumbnail-hover: $c-primary !default;
 $bdrs-molecule-thumbnail: initial !default;
 $bs-molecule-thumbnail: none !default;
+$o-molecule-thumbnail: visible !default;
 $p-molecule-thumbnail-image: 0 !default;
 $bgc-molecule-thumbnail-caption: color-variation($c-gray-light, 3) !default;
 $c-molecule-thumbnail-caption: $c-primary !default;
 $fz-molecule-thumbnail-caption: $fz-s !default;
 $ta-molecule-thumbnail-caption: center !default;
-$o-molecule-thumbnail: visible !default;
+$w-molecule-thumbnail-caption: calc(100% - #{$p-m * 2} - #{$bdw-s * 2});
 $bd-molecule-thumbnail-container-image: 0 !default;
 
 $sizes-molecule-thumbnail: (
@@ -39,8 +40,8 @@ $ratios-molecule-thumbnail: (
 
 .sui-MoleculeThumbnail {
   background-color: $bgc-molecule-thumbnail;
-  border: $bd-molecule-thumbnail;
   border-radius: $bdrs-molecule-thumbnail;
+  border: $bd-molecule-thumbnail;
   box-shadow: $bs-molecule-thumbnail;
   display: inline-block;
   margin: 0;
@@ -49,13 +50,13 @@ $ratios-molecule-thumbnail: (
   width: 100%;
 
   &-link {
-    display: inline-block;
     border: $bd-molecule-thumbnail;
+    display: inline-block;
     text-decoration: none;
 
     &:hover {
-      border-color: $bdc-molecule-thumbnail-hover;
       background-color: $bgc-molecule-thumbnail-hover;
+      border-color: $bdc-molecule-thumbnail-hover;
 
       .sui-MoleculeThumbnail-containerImage {
         border: $bd-molecule-thumbnail-container-image;
@@ -71,9 +72,9 @@ $ratios-molecule-thumbnail: (
     }
 
     .sui-MoleculeThumbnail-containerImage {
+      border: $bd-molecule-thumbnail-container-image;
       border-radius: $bdrs-rounded;
       overflow: hidden;
-      border: $bd-molecule-thumbnail-container-image;
     }
 
     .sui-MoleculeThumbnail-caption {
@@ -92,7 +93,7 @@ $ratios-molecule-thumbnail: (
     text-align: $ta-molecule-thumbnail-caption;
     text-overflow: ellipsis;
     white-space: nowrap;
-    width: 100%;
+    width: $w-molecule-thumbnail-caption;
   }
 
   &-containerImage {

--- a/components/molecule/thumbnail/src/settings.js
+++ b/components/molecule/thumbnail/src/settings.js
@@ -1,0 +1,22 @@
+export const BASE_CLASS = 'sui-MoleculeThumbnail'
+export const CAPTION_CLASS = `${BASE_CLASS}-caption`
+export const LINK_CLASS = `${BASE_CLASS}-link`
+export const CONTAINER_IMAGE = `${BASE_CLASS}-containerImage`
+
+export const THUMBNAIL_SIZES = {
+  LARGE: 'large',
+  MEDIUM: 'medium',
+  SMALL: 'small',
+  XSMALL: 'xsmall'
+}
+
+export const THUMBNAIL_RATIOS = {
+  '1:1': '1-1',
+  '4:3': '4-3',
+  '16:9': '16-9'
+}
+
+export const THUMBNAIL_SHAPES = {
+  SQUARED: 'squared',
+  CIRCLED: 'circled'
+}


### PR DESCRIPTION
## MOLECULE/THUMBNAIL
**TASK**: #1769 

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor

### Description, Motivation and Context
Fix 1:1 ratio width to achieve pixel-perfect badged 🥳.
Improve demo ^_^.
Also, fix caption width.

### Screenshots - Animations
![image](https://user-images.githubusercontent.com/3933098/137042495-95b717e5-f687-460e-82d2-fea1e372f68b.png)

### Fixed 🐛  🔫 
![image](https://user-images.githubusercontent.com/3933098/137037211-9421ebe4-0d7f-4e4a-a6a9-2e3ea7fa68a8.png)

