### PR TITLE
fix(components/atom/button): center isLoading spinner on atom button

### DIFF
--- a/components/atom/button/src/index.scss
+++ b/components/atom/button/src/index.scss
@@ -237,6 +237,8 @@ $icon-stroke-color: currentColor !default;
   }
 
   &-centerIcon {
+    align-items: center;
+    justify-content: center;
     position: absolute;
   }
 


### PR DESCRIPTION
## atom/button
https://github.com/SUI-Components/sui-components/issues/1726


### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

### Description, Motivation and Context
This change fix misalignment problem with AtomButton Spinner when isLoading prop is true

### Screenshots - Animations

https://user-images.githubusercontent.com/17271365/136845054-42180f96-42bd-4c56-8e9e-343e37410530.mov


