### PR TITLE
refactor(components/molecule/dropdownOption): fix border radius variable spelling

### DIFF
--- a/components/molecule/dropdownOption/src/index.scss
+++ b/components/molecule/dropdownOption/src/index.scss
@@ -3,7 +3,8 @@
 @import './settings';
 
 $c-molecule-dropdown-option--highlight-mark: initial !default;
-$bdrs-molecule-dropdown-option: 0 !default;
+$bdr-molecule-dropdown-option: 0 !default;
+$bdrs-molecule-dropdown-option: $bdr-molecule-dropdown-option !default;
 $bg-molecule-dropdown-option--highlight-mark: $c-highlight !default;
 $bg-molecule-dropdown-option-selected: none !default;
 $fw-molecule-dropdown-option-selected-text: $fw-bold !default;

--- a/components/molecule/dropdownOption/src/index.scss
+++ b/components/molecule/dropdownOption/src/index.scss
@@ -3,7 +3,7 @@
 @import './settings';
 
 $c-molecule-dropdown-option--highlight-mark: initial !default;
-$bdr-molecule-dropdown-option: 0 !default;
+$bdrs-molecule-dropdown-option: 0 !default;
 $bg-molecule-dropdown-option--highlight-mark: $c-highlight !default;
 $bg-molecule-dropdown-option-selected: none !default;
 $fw-molecule-dropdown-option-selected-text: $fw-bold !default;
@@ -24,7 +24,7 @@ $ml-molecule-dropdown-option: 0 !default;
 
 .sui-MoleculeDropdownOption {
   align-items: center;
-  border-radius: $bdr-molecule-dropdown-option;
+  border-radius: $bdrs-molecule-dropdown-option;
   display: flex;
   min-height: $mih-dropdown-option;
   padding: $pt-molecule-dropdown-option $pr-molecule-dropdown-option


### PR DESCRIPTION
## molecule/dropdownOption
**TASK**: https://github.com/SUI-Components/sui-components/issues/1745

### Types of changes
<!--- What types of changes does your code introduce? Put an ` x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [x] Refactor

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

The variable doesn't follow the SUI naming rules, `$bdr` is for border-right whereas `$bdrs` is the correct name for border radius
