### PR TITLE
fix(components/atom/label): Changed demo label and src

### DIFF
--- a/components/atom/label/demo/index.js
+++ b/components/atom/label/demo/index.js
@@ -46,8 +46,8 @@ const Demo = () => {
                 <AtomLabel
                   name={`atomLabelName-${key}`}
                   for={`labelName-${key}`}
-                  text={`label ${value}`}
-                  optionalText="*"
+                  text={`Label ${value}`}
+                  optionalText="(Optional)"
                   type={value}
                 />
                 <Input />
@@ -77,8 +77,8 @@ const Demo = () => {
                   <AtomLabel
                     name={`atomLabelName-${value}`}
                     for={`labelName-${value}`}
-                    text={`label ${value}`}
-                    optionalText="*"
+                    text={`Label ${value}`}
+                    optionalText="(Optional)"
                     inline={value}
                   />
                   {value !== 'right' && component}
@@ -103,7 +103,7 @@ const Demo = () => {
                   <AtomLabel
                     name={`atomLabelName-${key}`}
                     for={`labelName-${key}`}
-                    text={`size ${value}`}
+                    text={`Size ${value}`}
                     fontSize={value}
                   />
                   <Input />

--- a/components/atom/label/src/index.scss
+++ b/components/atom/label/src/index.scss
@@ -15,6 +15,7 @@ $fz-atom-label: $fz-base !default;
   color: $c-atom-label;
   font-size: $fz-atom-label;
   font-weight: $fw-atom-label;
+  margin-bottom: 4px;
 
   &-optionalText {
     color: $c-atom-label-optional;

--- a/components/molecule/checkboxField/demo/index.js
+++ b/components/molecule/checkboxField/demo/index.js
@@ -11,6 +11,17 @@ const styleListItem = {
   marginTop: '50px'
 }
 
+const styleBorderedContainer = {
+  display: 'flex',
+  border: '1px dashed #000'
+}
+
+const styleCenteredText = {
+  flexGrow: 1,
+  display: 'flex',
+  alignItems: 'center'
+}
+
 const Demo = () => {
   return (
     <div className="sui-StudioPreview">
@@ -44,8 +55,8 @@ const Demo = () => {
               id="info-help-text"
               fullWidth
               nodeLabel={
-                <div style={{display: 'flex', border: '1px dashed #000'}}>
-                  <div style={{flexGrow: 1}}>I'm full width</div>
+                <div style={styleBorderedContainer}>
+                  <div style={styleCenteredText}>I'm full width</div>
                   <button>Action</button>
                 </div>
               }


### PR DESCRIPTION
Added bottom margin on label and optional text on demo

ISSUES CLOSED: 1752

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
Added (Optiona) instead of *
Added 4px bottom margin to label class
Input is being imported from sui library, so maybe the requirement is to use "AtomInput" instead, anyway i tried to import the AtomInput but i have troubles with the css.

### Screenshots - Animations
![Selection_005](https://user-images.githubusercontent.com/20232667/137145202-c2e291ff-a3cc-4619-a1cb-595a37799a28.png)
![uppercased label name](https://user-images.githubusercontent.com/20232667/137145211-95120728-9b5b-4232-ac60-0673040d0810.png)

