### PR TITLE
feat(components/atom/checkbox): Add size option small and medium

### DIFF
--- a/components/atom/checkbox/demo/index.js
+++ b/components/atom/checkbox/demo/index.js
@@ -1,6 +1,9 @@
 /* eslint-disable no-console */
 import {useState, Fragment} from 'react'
-import AtomCheckbox, {checkboxStatus} from 'components/atom/checkbox/src'
+import AtomCheckbox, {
+  checkboxStatus,
+  checkboxSizes
+} from 'components/atom/checkbox/src'
 import AtomIcon from '@s-ui/react-atom-icon'
 
 import {
@@ -24,6 +27,7 @@ const BASE_CLASS_DEMO = `DemoAtomCheckbox`
 const CLASS_SECTION = `${BASE_CLASS_DEMO}-section`
 
 const CHECKBOX_STATUS = ['', ...Object.values(checkboxStatus)]
+const CHECKBOX_SIZE = [...Object.values(checkboxSizes)]
 
 const ICONS = {
   aiOutlineCheck: (
@@ -95,6 +99,56 @@ const Demo = () => {
           checkedIcon={() => ICONS.aiOutlineCheck}
           intermediateIcon={() => ICONS.aiOutlineLine}
         />
+      </Article>
+      <br />
+      <Article className={CLASS_SECTION}>
+        <H2>Sizes</H2>
+        <Paragraph>
+          There are 2 options for <Code>size</Code> medium being the default
+          one. To change it to small one has to pass the value{' '}
+          <Code>"small"</Code> to the size prop.
+        </Paragraph>
+        <Grid cols={4} gutter={[10, 10]}>
+          <Cell />
+          {Object.entries({
+            checked: {checked: true},
+            intermediate: {intermediate: true},
+            unchecked: {checked: false}
+          }).map(([label], index2) => (
+            <Fragment key={index2}>
+              <Cell style={flexCenteredStyle}>
+                <Label>{label}</Label>
+              </Cell>
+            </Fragment>
+          ))}
+
+          {CHECKBOX_SIZE.map((size, index) => (
+            <Fragment key={index}>
+              <Cell
+                style={{...flexCenteredStyle, justifyContent: 'flex-start'}}
+              >
+                <Label>{size || 'UNDEFINED'}</Label>
+              </Cell>
+              {Object.entries({
+                checked: {checked: true},
+                intermediate: {intermediate: true},
+                unchecked: {checked: false}
+              }).map(([label, props], index2) => (
+                <Fragment key={index2}>
+                  <Cell style={flexCenteredStyle}>
+                    <AtomCheckbox
+                      id={`${index}-${index2}`}
+                      checkedIcon={() => ICONS.aiOutlineCheck}
+                      intermediateIcon={() => ICONS.aiOutlineLine}
+                      {...{...props}}
+                      size={size}
+                    />
+                  </Cell>
+                </Fragment>
+              ))}
+            </Fragment>
+          ))}
+        </Grid>
       </Article>
       <br />
       <Article className={CLASS_SECTION}>

--- a/components/atom/checkbox/src/index.js
+++ b/components/atom/checkbox/src/index.js
@@ -9,6 +9,7 @@ const CHECKBOX_STATUS = {
   SUCCESS: 'success',
   ALERT: 'alert'
 }
+const CHECKBOX_SIZES = {SMALL: 'small', MEDIUM: 'medium'}
 
 const AtomCheckbox = ({
   checked = false,
@@ -21,6 +22,7 @@ const AtomCheckbox = ({
   name,
   onChange: onChangeFromProps = () => {},
   status,
+  size = CHECKBOX_SIZES.MEDIUM,
   ...props
 }) => {
   const inputRef = useRef()
@@ -43,6 +45,7 @@ const AtomCheckbox = ({
   }
 
   const className = cx(BASE_CLASS, {
+    [`${BASE_CLASS}--${size}`]: Object.values(CHECKBOX_SIZES).includes(size),
     'is-checked': checked,
     'is-disabled': disabled,
     'is-intermediate': isIntermediate,
@@ -80,6 +83,9 @@ AtomCheckbox.propTypes = {
   /* The DOM id global attribute. */
   id: PropTypes.string,
 
+  /* Determine the size of the checkbox. (default: CHECKBOX_SIZES.MEDIUM) */
+  size: PropTypes.string,
+
   /* Name attribute for the input */
   name: PropTypes.string,
 
@@ -110,3 +116,4 @@ AtomCheckbox.propTypes = {
 
 export default AtomCheckbox
 export {CHECKBOX_STATUS as checkboxStatus}
+export {CHECKBOX_SIZES as checkboxSizes}

--- a/components/atom/checkbox/src/index.scss
+++ b/components/atom/checkbox/src/index.scss
@@ -2,6 +2,8 @@
 
 $bdrs-atom-checkbox: $bdrs-m !default;
 $c-atom-checkbox: $c-white !default;
+$h-atom-checkbox-small: $sz-icon-s !default;
+$w-atom-checkbox-small: $sz-icon-s !default;
 $h-atom-checkbox: $sz-icon-m !default;
 $w-atom-checkbox: $sz-icon-m !default;
 $h-atom-checkbox-icon: $sz-icon-s !default;
@@ -37,6 +39,14 @@ $status-atom-checkbox: success $c-atom-checkbox--success,
 
 .sui-AtomCheckbox {
   $self: &;
+
+  &:not(&--native) {
+    &#{$self}--small {
+      height: $h-atom-checkbox-small;
+      width: $w-atom-checkbox-small;
+      min-width: $w-atom-checkbox-small;
+    }
+  }
 
   &:not(&--native) {
     align-items: center;


### PR DESCRIPTION
## atom/checkbox
**TASK**: #1732


### Types of changes

- [x] New feature (non-breaking change which adds functionality)


### Description, Motivation and Context
- Added size option for checkbox component
- Sizes available via prop are medium(default) and small

### Screenshots - Animations
<img width="1417" alt="Screenshot 2021-10-17 at 20 20 06" src="https://user-images.githubusercontent.com/30704597/137639938-1bcd372e-2a58-49cf-8757-ec6ffc1034c3.png">


