### PR TITLE
Feat/add highlight query value for custom children content

### DIFF
--- a/components/molecule/dropdownOption/demo/index.js
+++ b/components/molecule/dropdownOption/demo/index.js
@@ -68,7 +68,16 @@ const Demo = () => (
             Indiana Jones
           </MoleculeDropdownOption>
         </div>
-
+        <h3>With text highlighted (custom children content)</h3>
+        <div className={CLASS_DEMO_OPTION}>
+          <MoleculeDropdownOption
+            value="indiana jones"
+            highlightQuery="indi"
+            highlightValue="indiana jones"
+          >
+            🤠 with custom children content (not value)
+          </MoleculeDropdownOption>
+        </div>
         <h3>With callback (click & enter)</h3>
         <div className={CLASS_DEMO_OPTION}>
           <MoleculeDropdownOption

--- a/components/molecule/dropdownOption/src/index.js
+++ b/components/molecule/dropdownOption/src/index.js
@@ -147,7 +147,7 @@ MoleculeDropdownOption.propTypes = {
   selected: PropTypes.bool,
   /** Text to be highlighted in the option text if found */
   highlightQuery: PropTypes.string,
-  /** Text to be highlighted in the option text if found */
+  /** Text to be display if used with highlight query with custom content */
   highlightValue: PropTypes.string,
   /* key to provoke the onClick callback. Valid any value defined here → https://www.w3.org/TR/uievents-key/#named-key-attribute-values */
   onSelectKey: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),

--- a/components/molecule/dropdownOption/src/index.js
+++ b/components/molecule/dropdownOption/src/index.js
@@ -10,7 +10,6 @@ const MODIFIER_TWO_LINES = `twoLines`
 const MODIFIER_THREE_LINES = `threeLines`
 const MODIFIER_NO_WRAP = 'noWrap'
 const MODIFIER_LINE_WRAP = 'lineWrap'
-const CLASS_ITEM = `${BASE_CLASS}-item`
 const CLASS_TEXT = `${BASE_CLASS}-text`
 const CLASS_DISABLED = `${BASE_CLASS}--disabled`
 const CLASS_HIGHLIGHTED = `is-highlighted`
@@ -76,25 +75,15 @@ const MoleculeDropdownOption = ({
       endTag: '</mark>'
     })
 
-    if (highlightValue) {
-      return (
-        <div className={CLASS_ITEM}>
-          <span
-            onFocus={handleInnerFocus}
-            dangerouslySetInnerHTML={{__html: mark}}
-            className={innerClassName}
-          />
-          {children}
-        </div>
-      )
-    }
-
     return (
-      <span
-        onFocus={handleInnerFocus}
-        dangerouslySetInnerHTML={{__html: mark}}
-        className={innerClassName}
-      />
+      <>
+        <span
+          onFocus={handleInnerFocus}
+          dangerouslySetInnerHTML={{__html: mark}}
+          className={innerClassName}
+        />
+        {highlightValue ? children : null}
+      </>
     )
   }
   const handleInnerFocus = ev => {

--- a/components/molecule/dropdownOption/src/index.js
+++ b/components/molecule/dropdownOption/src/index.js
@@ -10,6 +10,7 @@ const MODIFIER_TWO_LINES = `twoLines`
 const MODIFIER_THREE_LINES = `threeLines`
 const MODIFIER_NO_WRAP = 'noWrap'
 const MODIFIER_LINE_WRAP = 'lineWrap'
+const CLASS_ITEM = `${BASE_CLASS}-item`
 const CLASS_TEXT = `${BASE_CLASS}-text`
 const CLASS_DISABLED = `${BASE_CLASS}--disabled`
 const CLASS_HIGHLIGHTED = `is-highlighted`
@@ -25,6 +26,7 @@ const MoleculeDropdownOption = ({
   children,
   disabled,
   highlightQuery,
+  highlightValue,
   innerRef,
   onSelectKey,
   onSelect,
@@ -73,6 +75,20 @@ const MoleculeDropdownOption = ({
       )}">`,
       endTag: '</mark>'
     })
+
+    if (highlightValue) {
+      return (
+        <div className={CLASS_ITEM}>
+          <span
+            onFocus={handleInnerFocus}
+            dangerouslySetInnerHTML={{__html: mark}}
+            className={innerClassName}
+          />
+          {children}
+        </div>
+      )
+    }
+
     return (
       <span
         onFocus={handleInnerFocus}
@@ -102,7 +118,7 @@ const MoleculeDropdownOption = ({
         />
       )}
       {highlightQuery ? (
-        renderHighlightOption(children)
+        renderHighlightOption(highlightValue || children)
       ) : (
         <span onFocus={handleInnerFocus} className={innerClassName}>
           {children}
@@ -131,6 +147,8 @@ MoleculeDropdownOption.propTypes = {
   selected: PropTypes.bool,
   /** Text to be highlighted in the option text if found */
   highlightQuery: PropTypes.string,
+  /** Text to be highlighted in the option text if found */
+  highlightValue: PropTypes.string,
   /* key to provoke the onClick callback. Valid any value defined here → https://www.w3.org/TR/uievents-key/#named-key-attribute-values */
   onSelectKey: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
   /** Custom ref handler that will be assigned to the "target" element */


### PR DESCRIPTION
## MOLECULE/DROPDOWN_OPTION

### Types of changes


- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context

- Add the custom content with the component children and higlihtQuery funcionality.

Problem when adding content in the children of the component, in this way, through the `higlihtValue` prop, it matches to apply the `<mark>` through the `higlightQuery` prop and we can also have custom content within the component.

We make the component backward compatible with the rest of functionalities.

### Screenshots - Animations

![CleanShot 2021-10-18 at 13 12 08](https://user-images.githubusercontent.com/1427623/137720142-1f54c390-9b81-4505-af05-9cfa52e76f89.png)

