### PR TITLE
Fix/drawer internal state

### DIFF
--- a/components/molecule/drawer/demo/index.js
+++ b/components/molecule/drawer/demo/index.js
@@ -32,12 +32,7 @@ const Demo = () => {
         placement={moleculeDrawerPlacements.BOTTOM}
         size={moleculeDrawerSizes.M}
         isOpen={isOpen}
-        onOpen={(event, {isOpen}) => {
-          setIsOpen(isOpen)
-        }}
-        onClose={(event, {isOpen}) => {
-          setIsOpen(isOpen)
-        }}
+        onClose={() => setIsOpen(false)}
       >
         <Paragraph>
           Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis,

--- a/components/molecule/drawer/src/Drawer.js
+++ b/components/molecule/drawer/src/Drawer.js
@@ -33,6 +33,7 @@ const MoleculeDrawer = forwardRef(
       event.preventDefault()
       if (event.key === 'Escape') {
         setIsOpenState(false, true)
+        onClose(event, {isOpen: false})
       }
     })
 

--- a/components/molecule/drawer/src/Drawer.js
+++ b/components/molecule/drawer/src/Drawer.js
@@ -1,4 +1,4 @@
-import {forwardRef, useEffect, useState, useCallback} from 'react'
+import {forwardRef, useEffect, useCallback} from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 import useEventListener from '@s-ui/react-hooks/lib/useEventListener'
@@ -20,7 +20,6 @@ const MoleculeDrawer = forwardRef(
     forwardedRef
   ) => {
     const [isOpenState, setIsOpenState] = useControlledState(isOpen) // inner state
-    const [isOpenedState, setIsOpenedState] = useState(isOpen) // transition delayed state
     useEffect(() => {
       if (target !== undefined) {
         target.current.style.position = 'relative'
@@ -39,18 +38,13 @@ const MoleculeDrawer = forwardRef(
 
     const onTransitionEndHandler = useCallback(
       event => {
-        setIsOpenedState(isOpenState)
-        if (isOpenState && !isOpenedState && typeof onOpen === 'function') {
+        if (isOpenState && typeof onOpen === 'function') {
           onOpen(event, {isOpen: isOpenState})
-        } else if (
-          !isOpenState &&
-          isOpenedState &&
-          typeof onClose === 'function'
-        ) {
+        } else if (!isOpenState && typeof onClose === 'function') {
           onClose(event, {isOpen: isOpenState})
         }
       },
-      [setIsOpenedState, isOpenState, isOpenedState, onClose, onOpen]
+      [isOpenState, onClose, onOpen]
     )
 
     return (


### PR DESCRIPTION
## MOLECULE/DRAWER
**TASK**: <!--- [jira TASK ID](jiraURL) -->


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
When pressing ESCAPE key we were not calling the onClose callback so the outer state turnes unsync with the inner state, in the current demo is not correctly appreciated because the outer state is managed as setIsOpen(!isOpen) but you have to press the button 2 times in order to be able to open the drawer again. 

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
