### PR TITLE
fix(components/atom/tag): fix icon alignment

### DIFF
--- a/components/atom/tag/src/index.scss
+++ b/components/atom/tag/src/index.scss
@@ -7,7 +7,7 @@ $base-class: '.sui-AtomTag';
 @mixin icon-atom-tag($type) {
   align-items: center;
   @include sui-icon--small;
-  display: inline-flex;
+  display: flex;
   justify-content: center;
   line-height: initial;
   vertical-align: middle;

--- a/components/atom/tag/src/index.scss
+++ b/components/atom/tag/src/index.scss
@@ -5,8 +5,10 @@
 $base-class: '.sui-AtomTag';
 
 @mixin icon-atom-tag($type) {
+  align-items: center;
   @include sui-icon--small;
-  display: inline-block;
+  display: inline-flex;
+  justify-content: center;
   line-height: initial;
   vertical-align: middle;
 }


### PR DESCRIPTION
ISSUES CLOSED: #1844

## atom/tag
**TASK**: N/A


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
As explained in issue #1844 tag icon was not aligned with content. This PR fixes this behaviour even if the given icon has parent elements (e.g. span).

### Screenshots - Animations
![dea611c1a5fa57d6c60d6422d2802b2d](https://user-images.githubusercontent.com/22194171/138297763-81531f10-0f84-48a5-acb7-e695b7310bb6.gif)
