### PR TITLE
fix(components/molecule/modal): Add a new prop to determine if the modal overflow is visible or not

### DIFF
--- a/components/molecule/modal/src/Content/_index.scss
+++ b/components/molecule/modal/src/Content/_index.scss
@@ -11,4 +11,8 @@
     margin: 0;
     padding: 0;
   }
+
+  &--visible-overflow {
+    overflow-y: visible;
+  }
 }

--- a/components/molecule/modal/src/Content/index.js
+++ b/components/molecule/modal/src/Content/index.js
@@ -6,12 +6,14 @@ const MoleculeModalContent = ({
   className: classNameProp,
   enableContentScroll,
   withoutIndentation,
+  visibleOverflow,
   ...others
 }) => {
   const baseClassName = 'sui-MoleculeModalContent'
   const contentRef = useRef()
   const className = cx(baseClassName, {
-    [`${baseClassName}--without-indentation`]: withoutIndentation
+    [`${baseClassName}--without-indentation`]: withoutIndentation,
+    [`${baseClassName}--visible-overflow`]: visibleOverflow
   })
 
   const preventScrollIfNeeded = ev => {
@@ -45,7 +47,8 @@ const MoleculeModalContent = ({
 MoleculeModalContent.propTypes = {
   className: PropTypes.string,
   enableContentScroll: PropTypes.bool,
-  withoutIndentation: PropTypes.bool
+  withoutIndentation: PropTypes.bool,
+  visibleOverflow: PropTypes.bool
 }
 
 export default MoleculeModalContent

--- a/components/molecule/modal/src/Content/index.js
+++ b/components/molecule/modal/src/Content/index.js
@@ -6,14 +6,14 @@ const MoleculeModalContent = ({
   className: classNameProp,
   enableContentScroll,
   withoutIndentation,
-  visibleOverflow,
+  isOverflowVisible,
   ...others
 }) => {
   const baseClassName = 'sui-MoleculeModalContent'
   const contentRef = useRef()
   const className = cx(baseClassName, {
     [`${baseClassName}--without-indentation`]: withoutIndentation,
-    [`${baseClassName}--visible-overflow`]: visibleOverflow
+    [`${baseClassName}--visible-overflow`]: isOverflowVisible
   })
 
   const preventScrollIfNeeded = ev => {
@@ -48,7 +48,7 @@ MoleculeModalContent.propTypes = {
   className: PropTypes.string,
   enableContentScroll: PropTypes.bool,
   withoutIndentation: PropTypes.bool,
-  visibleOverflow: PropTypes.bool
+  isOverflowVisible: PropTypes.bool
 }
 
 export default MoleculeModalContent

--- a/components/molecule/modal/src/MoleculeModal.js
+++ b/components/molecule/modal/src/MoleculeModal.js
@@ -39,7 +39,7 @@ const MoleculeModal = forwardRef(
       withoutIndentation = false,
       isContentless,
       withAnimation = true,
-      visibleOverflow = false
+      isOverflowVisible = false
     },
     forwardedRef
   ) => {
@@ -129,7 +129,7 @@ const MoleculeModal = forwardRef(
         [suitClass({element: 'dialog--out'})]: isClosing,
         [suitClass({element: 'dialog--fit'})]: fitContent,
         [suitClass({element: `dialog--size-${size}`})]: !!size,
-        [suitClass({element: 'dialog--visible'})]: visibleOverflow
+        [suitClass({element: 'dialog--overflowVisible'})]: isOverflowVisible
       })
 
       return (
@@ -161,7 +161,7 @@ const MoleculeModal = forwardRef(
               <MoleculeModalContent
                 enableContentScroll={enableContentScroll}
                 withoutIndentation={withoutIndentation}
-                visibleOverflow={visibleOverflow}
+                isOverflowVisible={isOverflowVisible}
               >
                 {renderChildren()}
               </MoleculeModalContent>
@@ -276,7 +276,7 @@ MoleculeModal.propTypes = {
   /**
    * Determines if the modal overflow is visible or not
    */
-  visibleOverflow: PropTypes.bool
+  isOverflowVisible: PropTypes.bool
 }
 
 MoleculeModal.displayName = 'MoleculeModal'

--- a/components/molecule/modal/src/MoleculeModal.js
+++ b/components/molecule/modal/src/MoleculeModal.js
@@ -129,7 +129,7 @@ const MoleculeModal = forwardRef(
         [suitClass({element: 'dialog--out'})]: isClosing,
         [suitClass({element: 'dialog--fit'})]: fitContent,
         [suitClass({element: `dialog--size-${size}`})]: !!size,
-        [suitClass({element: 'dialog--overflowVisible'})]: isOverflowVisible
+        [suitClass({element: 'dialog--visible-overflow'})]: isOverflowVisible
       })
 
       return (

--- a/components/molecule/modal/src/MoleculeModal.js
+++ b/components/molecule/modal/src/MoleculeModal.js
@@ -38,7 +38,8 @@ const MoleculeModal = forwardRef(
       usePortal = true,
       withoutIndentation = false,
       isContentless,
-      withAnimation = true
+      withAnimation = true,
+      visibleOverflow = false
     },
     forwardedRef
   ) => {
@@ -127,7 +128,8 @@ const MoleculeModal = forwardRef(
       const dialogClassName = cx(suitClass({element: 'dialog'}), {
         [suitClass({element: 'dialog--out'})]: isClosing,
         [suitClass({element: 'dialog--fit'})]: fitContent,
-        [suitClass({element: `dialog--size-${size}`})]: !!size
+        [suitClass({element: `dialog--size-${size}`})]: !!size,
+        [suitClass({element: 'dialog--visible'})]: visibleOverflow
       })
 
       return (
@@ -159,6 +161,7 @@ const MoleculeModal = forwardRef(
               <MoleculeModalContent
                 enableContentScroll={enableContentScroll}
                 withoutIndentation={withoutIndentation}
+                visibleOverflow={visibleOverflow}
               >
                 {renderChildren()}
               </MoleculeModalContent>
@@ -269,7 +272,11 @@ MoleculeModal.propTypes = {
   /**
    * Determines if modal has open/close animation
    */
-  withAnimation: PropTypes.bool
+  withAnimation: PropTypes.bool,
+  /**
+   * Determines if the modal overflow is visible or not
+   */
+  visibleOverflow: PropTypes.bool
 }
 
 MoleculeModal.displayName = 'MoleculeModal'

--- a/components/molecule/modal/src/index.scss
+++ b/components/molecule/modal/src/index.scss
@@ -143,6 +143,10 @@ body.is-MoleculeModal-open {
       }
     }
 
+    &--visible {
+      overflow: visible;
+    }
+
     @each $key-size, $size in $s-molecule-modal-dialog {
       &--size-#{$key-size} {
         width: 100%;

--- a/components/molecule/modal/src/index.scss
+++ b/components/molecule/modal/src/index.scss
@@ -143,7 +143,7 @@ body.is-MoleculeModal-open {
       }
     }
 
-    &--overflowVisible {
+    &--visible-overflow {
       overflow: visible;
     }
 

--- a/components/molecule/modal/src/index.scss
+++ b/components/molecule/modal/src/index.scss
@@ -143,7 +143,7 @@ body.is-MoleculeModal-open {
       }
     }
 
-    &--visible {
+    &--overflowVisible {
       overflow: visible;
     }
 


### PR DESCRIPTION
## molecule/modal
**TASK**: https://github.com/SUI-Components/sui-components/issues/1515


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
When we include a component inside the modal component and its content is bigger than the modal itself, the modal is configured to add a vertical scroll.

Sometimes, for example when dropdown options are opened, we need that the modal doesn't show the scroll and the dropdown list should be opened over the modal content.

To solve it, I have added a new boolean prop `visibleOverflow`. When is `true`, components will be displayed over the modal otherwise a vertical scroll will be added if needed.

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
![image](https://user-images.githubusercontent.com/56223074/138298200-8814ae81-b5b6-44c5-a023-85cc68b2823d.png)

