### PR TITLE
fix(components/molecule/accordion): fix autoHeight borders behaviour

### DIFF
--- a/components/molecule/accordion/src/Tab/index.js
+++ b/components/molecule/accordion/src/Tab/index.js
@@ -37,7 +37,8 @@ const Tab = ({
     [OPEN_CLASS]: isOpen
   })
   const contentClassName = cx(CONTENT_CONTAINER_CLASS, {
-    [`${CONTENT_CONTAINER_CLASS}--withTransition`]: withTransition,
+    [`${CONTENT_CONTAINER_CLASS}--withTransition`]:
+      !autoHeight && withTransition,
     [`${CONTENT_CONTAINER_CLASS}--withScrollVisible`]: withScrollVisible
   })
 

--- a/components/molecule/accordion/src/Tab/index.js
+++ b/components/molecule/accordion/src/Tab/index.js
@@ -34,6 +34,8 @@ const Tab = ({
     [OPEN_CLASS]: isOpen
   })
   const containerClassName = cx(CONTAINER_BUTTON_CLASS, {
+    [`${CONTAINER_BUTTON_CLASS}--withTransition`]:
+      !autoHeight && withTransition,
     [OPEN_CLASS]: isOpen
   })
   const contentClassName = cx(CONTENT_CONTAINER_CLASS, {

--- a/components/molecule/accordion/src/_settings.scss
+++ b/components/molecule/accordion/src/_settings.scss
@@ -15,5 +15,7 @@ $p-accordion-title: $p-m $p-l !default;
 $ff-molecule-accordion-title: $ff-sans-serif !default;
 $fw-molecule-accordion-title: $fw-regular !default;
 $bxsh-accordion-tab-scrollbar-thumb: 0 0 1px $c-gray-lightest !default;
-$trs-accordion-tab-content: all 0.25s ease-in-out !default;
+$trs-accordion-tab-content: max-height 0.25s ease-in-out !default;
+$trs-accordion-tab-title: border-bottom 20ms ease-out !default;
+$trs-close-accordion-tab-title: border-bottom 0 ease-out !default;
 $m-accordion-tab-btn: $m-m !default;

--- a/components/molecule/accordion/src/index.scss
+++ b/components/molecule/accordion/src/index.scss
@@ -91,6 +91,10 @@ $base-class: '.sui-MoleculeAccordion-tab';
       overflow: auto;
     }
 
+    :not(.is-open) & {
+      border-top: $bd-accordion-tab-container-none;
+    }
+
     &--withScrollVisible {
       .is-open & {
         overflow-y: scroll;
@@ -108,10 +112,26 @@ $base-class: '.sui-MoleculeAccordion-tab';
   }
 
   &TitleContainer {
+    $self: &;
     background-color: $bgc-accordion-tab-container;
     position: relative;
     width: 100%;
     border-radius: $bdrs-accordion-tab;
+
+    &--withTransition.is-open {
+      border-bottom: $bd-accordion-tab-container; // this avoids glitches
+      transition: $trs-accordion-tab-title;
+    }
+
+    &.is-open {
+      border-bottom: $bd-accordion-tab-container; // border without transition
+    }
+
+    &:not(.is-open)#{$self}--withTransition {
+      border-bottom: $bd-accordion-tab-container-none;
+      transition: $trs-close-accordion-tab-title;
+      transition-delay: 230ms;
+    }
   }
 
   &Icon {


### PR DESCRIPTION
ISSUES CLOSED: #1711

## MOLECULE/ACCORDION
**TASK**: N/A


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
This PR solves the problems described in issue #1711 with an elegant & simple solution. 

Since css transition property does not work without specifying an element height (that can be done with JS, though the requirements of the issue doesn't ask for it) we just check withTransition prop if autoHeight is not enabled.

### Screenshots - Animations
1. Border disappearing on safari (solved)
![border-disappearing-safari](https://user-images.githubusercontent.com/22194171/138305658-74723151-a714-4d0c-bbaf-9c1aa0047514.gif)

2. Double border on close (solved)
![double-border-at-close](https://user-images.githubusercontent.com/22194171/138305919-f5d57af3-0908-479a-bb1c-a35db871a32b.gif)
