### PR TITLE
Feat use mixins instead of extends

### DIFF
--- a/components/atom/input/src/Input/Component/index.scss
+++ b/components/atom/input/src/Input/Component/index.scss
@@ -11,7 +11,7 @@ $base-class: '.sui-AtomInput-input';
 $class-read-only: '#{$base-class}--readOnly';
 
 #{$base-class} {
-  @extend %sui-atom-input-input;
+  @include sui-atom-input-input;
   border-radius: $bdrs-atom-input;
   min-height: auto;
   text-overflow: $tov-atom-input-placeholder;
@@ -63,7 +63,7 @@ $class-read-only: '#{$base-class}--readOnly';
   }
 
   &:focus {
-    @extend %sui-atom-input-input-focus;
+    @include sui-atom-input-input-focus;
   }
 
   @each $type, $attr in $sizes-atom-input {

--- a/components/atom/textarea/src/index.scss
+++ b/components/atom/textarea/src/index.scss
@@ -63,7 +63,7 @@ $base-class: '.sui-AtomTextarea';
   }
 
   &:focus {
-    @extend %sui-atom-input-input-focus;
+    @include sui-atom-input-input-focus;
   }
 
   &--short {

--- a/components/molecule/inputTags/src/index.scss
+++ b/components/molecule/inputTags/src/index.scss
@@ -12,7 +12,7 @@ $bg-input-tag-disable: $c-gray-light-4 !default;
 $bdrs-molecule-input-tags: 0 !default;
 
 #{$class-tags} {
-  @extend %sui-atom-input-input;
+  @include sui-atom-input-input;
   border-radius: $bdrs-molecule-input-tags;
   align-items: center;
   display: flex;
@@ -20,7 +20,7 @@ $bdrs-molecule-input-tags: 0 !default;
   padding: 0 0 0 $p-m;
 
   &--focus {
-    @extend %sui-atom-input-input-focus;
+    @include sui-atom-input-input-focus;
   }
 
   &--disabled {

--- a/components/molecule/select/src/index.scss
+++ b/components/molecule/select/src/index.scss
@@ -93,7 +93,7 @@ $c-molecule-select-disabled: inherit !default;
   &--focus {
     #{$class-input} {
       &-container {
-        @extend %sui-atom-input-select-focus;
+        @include sui-atom-input-select-focus;
         border: $bdw-s solid $c-primary;
 
         .sui-AtomInput-input,


### PR DESCRIPTION
There are some components using an `@extend` related to `sui-atom-input`.

We're replacing the use of `@extend` by the equivalent mixin. 

**DO NOT MERGE, YET**
A release of `sui-theme` with the changes on this PR is required: https://github.com/SUI-Components/sui/pull/1277

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [x] Refactor

### Description, Motivation and Context
The use of a `mixin` instead of an `@extend` helps us make our styles work with the `useExperimentalSCSSLoader` flag on.

### Screenshots - Animations
N/A