### PR TITLE
feat(components/atom/tag): add isFitted prop to disable the padding in the container

### DIFF
--- a/components/atom/tag/demo/ArticleIsFitted.js
+++ b/components/atom/tag/demo/ArticleIsFitted.js
@@ -1,0 +1,70 @@
+import {useState} from 'react'
+import PropTypes from 'prop-types'
+import {Article, H2, Paragraph, Code} from '@s-ui/documentation-library'
+import AtomTag, {atomTagDesigns} from 'components/atom/tag/src'
+
+const noop = () => null
+
+const ArticleIsFitted = ({className, icon: iconProp}) => {
+  const [disabled] = useState(false)
+  const [outlined] = useState(false)
+  const [actionable] = useState(false)
+  const [icon] = useState(null)
+  return (
+    <Article className={className}>
+      <H2>isFitted</H2>
+      <Paragraph>
+        <Code>isFitted</Code> boolean prop (default false) is provided to make a
+        transition between this and next major version. When it is true, the
+        element is margin-border and also padding-less it order to provide te
+        element boundings as is.
+      </Paragraph>
+      <AtomTag
+        label="Alert"
+        type="alert"
+        disabled={disabled}
+        design={outlined ? atomTagDesigns.OUTLINE : atomTagDesigns.SOLID}
+        icon={icon}
+        isFitted
+        {...{...(actionable && {onClick: noop})}}
+      />
+
+      <AtomTag
+        label="Warning"
+        type="warning"
+        disabled={disabled}
+        design={outlined ? atomTagDesigns.OUTLINE : atomTagDesigns.SOLID}
+        icon={icon}
+        isFitted
+        {...{...(actionable && {onClick: noop})}}
+      />
+
+      <AtomTag
+        label="Special"
+        type="special"
+        disabled={disabled}
+        design={outlined ? atomTagDesigns.OUTLINE : atomTagDesigns.SOLID}
+        icon={icon}
+        isFitted
+        {...{...(actionable && {onClick: noop})}}
+      />
+
+      <AtomTag
+        label="5 min ago"
+        type="date"
+        disabled={disabled}
+        design={outlined ? atomTagDesigns.OUTLINE : atomTagDesigns.SOLID}
+        icon={icon}
+        isFitted
+        {...{...(actionable && {onClick: noop})}}
+      />
+    </Article>
+  )
+}
+
+ArticleIsFitted.propTypes = {
+  className: PropTypes.string,
+  icon: PropTypes.node
+}
+
+export default ArticleIsFitted

--- a/components/atom/tag/demo/index.js
+++ b/components/atom/tag/demo/index.js
@@ -19,6 +19,7 @@ import {
 import ArticleTypes from './ArticleTypes'
 
 import './index.scss'
+import ArticleIsFitted from './ArticleIsFitted'
 
 const icon = (
   <AtomIcon size={ATOM_ICON_SIZES.small}>
@@ -349,5 +350,7 @@ export default () => (
     </Article>
     <br />
     <ArticleTypes className={CLASS_SECTION} icon={icon} />
+    <br />
+    <ArticleIsFitted className={CLASS_SECTION} icon={icon} />
   </div>
 )

--- a/components/atom/tag/src/index.js
+++ b/components/atom/tag/src/index.js
@@ -13,7 +13,17 @@ import {
 import {filterKeys} from './helpers'
 
 const AtomTag = props => {
-  const {design, href, icon, onClick, responsive, size, type, disabled} = props
+  const {
+    design,
+    href,
+    icon,
+    onClick,
+    responsive,
+    size,
+    type,
+    disabled,
+    isFitted = false
+  } = props
   const isActionable = onClick || href
   const classNames = cx(
     'sui-AtomTag',
@@ -22,7 +32,8 @@ const AtomTag = props => {
     icon && 'sui-AtomTag-hasIcon',
     responsive && 'sui-AtomTag--responsive',
     type && `sui-AtomTag--${type}`,
-    disabled && 'sui-AtomTag--disabled'
+    disabled && 'sui-AtomTag--disabled',
+    isFitted && 'sui-AtomTag--isFitted'
   )
 
   /**
@@ -107,7 +118,9 @@ AtomTag.propTypes = {
   /**
    * Value of the tag to be returned on actionable tags
    */
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /** element becomes border-margin-padding-less */
+  isFitted: PropTypes.nool
 }
 
 AtomTag.defaultProps = {

--- a/components/atom/tag/src/index.scss
+++ b/components/atom/tag/src/index.scss
@@ -42,6 +42,10 @@ $base-class: '.sui-AtomTag';
   position: relative;
   white-space: nowrap;
 
+  &--isFitted {
+    margin: 0;
+  }
+
   * ~ #{$base-class}-label {
     margin: 0 0 0 $m-s;
   }


### PR DESCRIPTION
ISSUES: #1708

## ATOM/TAG
**TASK**: <!--- [jira TASK ID](jiraURL) -->


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
This solves part of the isFitted epic #1667:
- [ ]  [button](https://sui-components.vercel.app/workbench/atom/button/demo)
- [ ]  [input](https://sui-components.vercel.app/workbench/atom/input/demo)
- [x]  [tag](https://sui-components.vercel.app/workbench/atom/tag/demo)
- [ ]  [breadcrumb](https://sui-components.vercel.app/workbench/molecule/breadcrumb/demo)

I decided to make the PR although it not closes the issue #1708 at all. I prefer that you could have a look at it, as this is my first issue in sui-components, and also my first experience with React, since I come from an Angular and Vue background.
If it is ok for atom/tag I'll continue with the other components later on 😊 

### Screenshots - Animations
![image](https://user-images.githubusercontent.com/5516760/139047602-2c9ba039-b617-436d-9fc3-6426abc10497.png)
