### PR TITLE
feat(components/molecule/stepper): add width separator in horizontal …

### DIFF
--- a/components/molecule/stepper/src/Step/index.scss
+++ b/components/molecule/stepper/src/Step/index.scss
@@ -236,7 +236,7 @@ $base-class-step: #{$base-class}Step;
       + #{$base-class-step}Connector {
         height: 100%;
         #{$base-class-step}ConnectorLine {
-          width: calc(100% - #{2 * ($m-stepper+ $bdw-stepper)});
+          width: $w-stepper-separator-horizontal;
           height: $h-stepper;
           margin: 3 * $sz-base $m-stepper 0 $m-stepper;
         }

--- a/components/molecule/stepper/src/Step/settings.scss
+++ b/components/molecule/stepper/src/Step/settings.scss
@@ -1,1 +1,3 @@
-// Do your magic
+$w-stepper-separator-horizontal: calc(
+  100% - #{2 * ($m-stepper+ $bdw-stepper)}
+) !default;


### PR DESCRIPTION
Add width separator in horizontal centered mode

## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
 #### `🔍 Show` 
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context

In the centered horizontal format we need a wider separator

### Screenshots - Animations

Before:

<img width="383" alt="Captura de Pantalla 2022-11-08 a las 16 25 15" src="https://user-images.githubusercontent.com/16401219/200605937-90ba684e-46d1-4d80-9672-7f4e4e51e36c.png">


After (Using theme var configuration):

<img width="913" alt="Captura de Pantalla 2022-11-08 a las 16 24 12" src="https://user-images.githubusercontent.com/16401219/200605830-c099e615-6d0d-4449-984c-410a7da1788d.png">
