### PR TITLE
feat(components/atom/switch): add scss tokens to fit motor theme

### DIFF
--- a/components/atom/switch/src/styles/index.scss
+++ b/components/atom/switch/src/styles/index.scss
@@ -232,14 +232,15 @@ $base-class: '.sui-AtomSwitch';
         padding-top: $p-s;
 
         #{$base-class}-inputContainer {
+          border-width: $bdw-atom-switch-input-container-large;
           height: $h-atom-switch-input-container-large;
           min-width: $w-atom-switch-large;
           width: $w-atom-switch-large;
 
           #{$base-class}-circle {
             border-radius: $w-atom-switch-large * 0.5;
-            height: $h-atom-switch-input-container-large - 2px;
-            width: $h-atom-switch-input-container-large - 2px;
+            height: $h-atom-switch-circle-large - 2px;
+            width: $w-atom-switch-circle-large - 2px;
           }
           &--right {
             #{$base-class}-circle {

--- a/components/atom/switch/src/styles/index.scss
+++ b/components/atom/switch/src/styles/index.scss
@@ -102,7 +102,7 @@ $base-class: '.sui-AtomSwitch';
 
     &:disabled {
       background-color: $c-gray-lightest;
-      border: $bdw-s solid $c-gray-lightest;
+      border: $bdw-atom-switch-default solid $c-gray-lightest;
       cursor: not-allowed;
       #{$base-class}-circle {
         background-color: $c-gray-lightest;
@@ -110,7 +110,7 @@ $base-class: '.sui-AtomSwitch';
     }
     &[aria-checked='true'] {
       background-color: $c-atom-switch--active;
-      border: $bdw-s solid $c-atom-switch--active;
+      border: $bdw-atom-switch-default solid $c-atom-switch--active;
       cursor: pointer;
       &:disabled {
         cursor: not-allowed;
@@ -135,7 +135,7 @@ $base-class: '.sui-AtomSwitch';
       border-radius: ($h-atom-switch-default - 2) * 0.5;
       border: $bdw-s solid $c-atom-switch-circle;
       box-shadow: 2px 0 2px 0 $c-gray-light;
-      height: $h-atom-switch-default - 2px;
+      height: $h-atom-switch-circle-default - 2px;
       width: $w-atom-switch-circle-default - 2px;
       transition: margin-left $atom-switch-transition-time ease-in-out;
       margin: 0px;

--- a/components/atom/switch/src/styles/settings.scss
+++ b/components/atom/switch/src/styles/settings.scss
@@ -11,6 +11,7 @@ $h-atom-switch-input-container-small: $h-atom-switch-small !default;
 $h-atom-switch-default: $sz-base * 3 !default;
 $h-atom-switch-container-default: $h-atom-switch-default + 10px !default;
 $w-atom-switch-default: $sz-base * 5 !default;
+$h-atom-switch-circle-default: $h-atom-switch-default !default;
 $w-atom-switch-circle-default: $h-atom-switch-default !default;
 $m-atom-switch-circle-default--active: $w-atom-switch-default -
   $w-atom-switch-circle-default !default;
@@ -30,7 +31,8 @@ $c-atom-switch--active-shadow: rgba($c-black, 0.2);
 $c-atom-switch--default: color-variation($c-gray, 3) !default;
 $c-atom-switch-circle: $c-white;
 
-$bd-atom-switch-default: $bdw-s solid
+$bdw-atom-switch-default: $bdw-s !default;
+$bd-atom-switch-default: $bdw-atom-switch-default solid
   color-variation($c-atom-switch--default, $c-dark-step) !default;
 $bxsh-atom-switch-container: 0 0 4px 0 transparent !default;
 

--- a/components/atom/switch/src/styles/settings.scss
+++ b/components/atom/switch/src/styles/settings.scss
@@ -21,9 +21,11 @@ $p-atom-switch-container: $p-s !default;
 $h-atom-switch-large: $sz-base * 4 !default;
 $h-atom-switch-container-large: $h-atom-switch-large + 10px !default;
 $w-atom-switch-large: $sz-base * 7 !default;
+$h-atom-switch-circle-large: $h-atom-switch-large !default;
 $w-atom-switch-circle-large: $h-atom-switch-large !default;
 $m-atom-switch-circle-large--active: $w-atom-switch-large -
   $w-atom-switch-circle-large !default;
+$bdw-atom-switch-input-container-large: $bdw-s !default;
 $h-atom-switch-input-container-large: $h-atom-switch-large !default;
 
 $c-atom-switch--active: color-variation($c-primary, 1) !default;


### PR DESCRIPTION
## Atom/Switch
#### `🔍 Show`

### Description, Motivation and Context
Add tokens to custom atom switch to fit motor theme component.

### Types of changes
- [x] 💄 Styles

### Screenshots - Animations
<img width="191" alt="Captura de pantalla 2023-05-15 a las 17 16 36" src="https://github.com/SUI-Components/sui-components/assets/37936498/bde37a13-9a14-4473-bac2-bdc39fbb8a1e">
