### PR TITLE
fix(components/molecule/dropdownOption): fix behaviour when AtomCheckbox changes state

### DIFF
--- a/components/molecule/dropdownOption/src/index.js
+++ b/components/molecule/dropdownOption/src/index.js
@@ -118,7 +118,7 @@ const MoleculeDropdownOption = forwardRef(
             checked={innerSelected}
             disabled={disabled}
             onChange={ev => {
-              onSelect(ev, {value})
+              typeof onSelect === 'function' && onSelect(ev, {value})
             }}
             onFocus={handleInnerFocus}
             {...checkboxProps}

--- a/components/molecule/dropdownOption/src/index.js
+++ b/components/molecule/dropdownOption/src/index.js
@@ -114,7 +114,15 @@ const MoleculeDropdownOption = forwardRef(
         {...Object.fromEntries(Object.entries(props).filter(([key]) => !['className', 'style'].includes(key)))}
       >
         {checkbox && (
-          <AtomCheckbox checked={innerSelected} disabled={disabled} onFocus={handleInnerFocus} {...checkboxProps} />
+          <AtomCheckbox
+            checked={innerSelected}
+            disabled={disabled}
+            onChange={ev => {
+              onSelect(ev, {value})
+            }}
+            onFocus={handleInnerFocus}
+            {...checkboxProps}
+          />
         )}
         {highlightQuery ? (
           renderHighlightOption(highlightValue || children)


### PR DESCRIPTION
## molecule/dropdownOption
`🔍 Show`


<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Description, Motivation and Context
When using a custom icon for the `atom/checkbox` on the `molecule/dropdownOption`, the state cannot be changed by checking / unchecking the checkbox once a first selection has been made.
As detailed on the following issue: https://github.com/SUI-Components/sui-components/issues/2709

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
