### PR TITLE
feat(components/molecule/selectPopover): add focus visible to button

### DIFF
--- a/components/molecule/selectPopover/src/styles/index.scss
+++ b/components/molecule/selectPopover/src/styles/index.scss
@@ -56,6 +56,12 @@ $base-class: '.sui-MoleculeSelectPopover ';
       }
     }
 
+    &:focus-visible {
+      box-shadow: $bxsh-atom-button-focus;
+      outline: 2px solid transparentize($c-primary, 0.2);
+      outline-offset: 2px;
+    }
+
     &:hover,
     &.is-open {
       background-color: $bgc-select-popover-hover;


### PR DESCRIPTION
## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->

<!-- #### `🔍 Show` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Description, Motivation and Context

Added `&:focus-visible` styles to improve accessibility, now the focus outline only shows when navigating with the keyboard `(like using Tab)`, 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [x] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
