### PR TITLE
feat(components/molecule/dropdownOption): set color to description text when option is selected

### DIFF
--- a/components/molecule/dropdownOption/src/styles/index.scss
+++ b/components/molecule/dropdownOption/src/styles/index.scss
@@ -101,6 +101,10 @@ $base-class: '.sui-MoleculeDropdownOption';
     align-items: stretch;
     justify-content: center;
     padding: $pt-molecule-dropdown-option-with-description $pl-molecule-dropdown-option;
+
+    &.is-selected {
+      color: $c-molecule-dropdown-option-selected-text;
+    }
   }
 
   &--withDescriptionAndAddon {


### PR DESCRIPTION
## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
<!-- #### `🔍 Show` -->
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
We need that when the `DropdownOption` has a description text and that option is selected, the color of the description text is the same as the color of the selected option.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [x] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
