### PR TITLE
docs(components/atom/switch): add design prop instead of deprecated type

### DIFF
--- a/components/atom/switch/README.md
+++ b/components/atom/switch/README.md
@@ -1,6 +1,5 @@
 # AtomSwitch
 
-
 The switch is the radio button when there’re only 2 exclusive options. “On/off” is a common and clear example for explaining this component.
 
 In order to collect the result of this switch there is a callback `onToggle`, this callback receives a flag on `true` if select is active. If you're using a `select` type of this component, `false` means the first option and `true` the second one.
@@ -39,7 +38,7 @@ return (
     labelRight="On"
     onToggle={flag => console.log(`Switch value is ${flag}`)}
     size="default"
-    type="toggle"
+    design="toggle"
   />
 )
 ```
@@ -54,7 +53,7 @@ return (
     labelLeft="Off"
     labelRight="On"
     onToggle={value => handleChangeFromParent(value)}
-    type="toggle"
+    design="toggle"
     value={value}
   />
 )


### PR DESCRIPTION
## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
`🔍 Show` 

### Description, Motivation and Context
Update the `design` prop for atom-switch in the README instead of using the deprecated `type` prop

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
