### PR TITLE
feat(components/molecule/carousel): Enhance arrow focus visibility

### DIFF
--- a/components/molecule/carousel/src/styles/index.scss
+++ b/components/molecule/carousel/src/styles/index.scss
@@ -26,6 +26,12 @@ $base-class: '.sui-MoleculeCarousel';
       background-color: $c-gray-light-3;
       outline: none;
     }
+    &:focus-visible {
+      opacity: 1;
+      box-shadow: $bxsh-molecule-carousel-arrow;
+      outline: 2px solid transparentize($c-primary, 0.2);
+      outline-offset: 2px;
+    }
     &:hover {
       background-color: $c-gray-light-4;
     }

--- a/components/molecule/carousel/src/styles/index.scss
+++ b/components/molecule/carousel/src/styles/index.scss
@@ -22,7 +22,7 @@ $base-class: '.sui-MoleculeCarousel';
     background-color: $c-gray-light-2;
     border: none;
 
-    &:focus {
+    &:focus:not(:focus-visible) {
       background-color: $c-gray-light-3;
       outline: none;
     }

--- a/components/molecule/carousel/src/styles/settings.scss
+++ b/components/molecule/carousel/src/styles/settings.scss
@@ -1,4 +1,5 @@
 $bgc-molecule-carousel: transparent !default;
+$bxsh-molecule-carousel-arrow: 0 1px 4px 0 rgba(0, 0, 0, 0.24) !default;
 $wthc-molecule-carousel: rgba(0, 0, 0, 0) !default;
 $c-nav-background: rgba(255, 255, 255, 0.8) !default;
 $c-nav-color: #aaaaaa !default;


### PR DESCRIPTION
## Molecule/Carousel
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
<!-- #### `🔍 Show` -->
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: [MTR-98018](https://jira.ets.mpi-internal.com/browse/MTR-98018)

### Description, Motivation and Context
<!--- Describe your changes in detail -->
- Improved keyboard accessibility for carousel navigation arrows by making them visible when focused via keyboard navigation.
<!--- Why is this change required? What problem does it solve? -->
- The carousel navigation arrows were only visible on hover, creating an accessibility issue for keyboard users. When navigating with the Tab key, users could focus on the arrow buttons but couldn't see them, making it impossible to know which element had focus.
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->

<img width="500" height="412" alt="image" src="https://github.com/user-attachments/assets/2432873e-d75d-495c-80a5-b88399560048" />

