### PR TITLE
fix(components/atom/input): fix error state styles in password input

### DIFF
--- a/components/atom/input/src/Password/index.js
+++ b/components/atom/input/src/Password/index.js
@@ -5,12 +5,15 @@ import PropTypes from 'prop-types'
 
 import useControlledState from '@s-ui/react-hooks/lib/useControlledState'
 
-import {INPUT_SHAPES} from '../config.js'
+import {INPUT_SHAPES, INPUT_STATES} from '../config.js'
 import Input from '../Input/index.js'
 import {BASE_CLASS_PASSWORD, BASE_CLASS_PASSWORD_TOGGLE_BUTTON, PASSWORD, TEXT} from './config.js'
 
 const Password = forwardRef(
-  ({onChange, shape, pwShowLabel, pwHideLabel, toggleAriaLabel, value, defaultValue = '', ...props}, forwardedRef) => {
+  (
+    {onChange, shape, pwShowLabel, pwHideLabel, toggleAriaLabel, value, defaultValue = '', state, ...props},
+    forwardedRef
+  ) => {
     const [type, setType] = useState(PASSWORD)
     const [innerValue, setInnerValue] = useControlledState(value, defaultValue)
 
@@ -25,7 +28,13 @@ const Password = forwardRef(
     }
 
     return (
-      <div className={cx(BASE_CLASS_PASSWORD, shape && `${BASE_CLASS_PASSWORD}-shape-${shape}`)}>
+      <div
+        className={cx(
+          BASE_CLASS_PASSWORD,
+          shape && `${BASE_CLASS_PASSWORD}-shape-${shape}`,
+          state && `${BASE_CLASS_PASSWORD}--state-${state}`
+        )}
+      >
         <Input
           ref={forwardedRef}
           shape={shape}
@@ -70,7 +79,9 @@ Password.propTypes = {
   /* The default value of the control */
   defaultValue: PropTypes.string,
   /** Sets the shape of the input field. It can be 'rounded', 'square' or 'circle' */
-  shape: PropTypes.oneOf(Object.values(INPUT_SHAPES))
+  shape: PropTypes.oneOf(Object.values(INPUT_SHAPES)),
+  /** 'success', 'error' or 'alert' */
+  state: PropTypes.oneOf(Object.values(INPUT_STATES))
 }
 
 export default Password

--- a/components/atom/input/src/Password/styles/index.scss
+++ b/components/atom/input/src/Password/styles/index.scss
@@ -43,4 +43,16 @@ $base-class-password: '#{$base-class-input}-password';
       outline-offset: 2px;
     }
   }
+
+  &--state-error {
+    border-color: $c-atom-input--error;
+  }
+
+  &--state-success {
+    border-color: $c-atom-input--success;
+  }
+
+  &--state-alert {
+    border-color: $c-atom-input--alert;
+  }
 }


### PR DESCRIPTION
## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
<!-- #### `🔍 Show` -->
#### `❓ Ask` 

### Description, Motivation and Context
This PR fixes error state styles of the password input field. The red border wasn't showing up because the styles were applied to the `input` element, but the password field uses a wrapper for the border, and the input itself has the `noBorder` prop

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
**Before**                          |  **After**
:-------------------------:|:-------------------------: 
<img width="2048" height="1027" alt="Screenshot 2025-09-02 at 17 49 22" src="https://github.com/user-attachments/assets/75b25e58-dd80-44c1-8e75-dfa4fc886f9c" /> | <img width="485" height="581" alt="Screenshot 2025-09-02 at 17 40 10" src="https://github.com/user-attachments/assets/1b884deb-c37a-4f30-9d23-74cb01f72ad8" />

