### PR TITLE
fix(components/atom/pinInput): fix character input on mobile virtual keyboards

### DIFF
--- a/components/atom/pinInput/src/hooks/useKeyPress.js
+++ b/components/atom/pinInput/src/hooks/useKeyPress.js
@@ -1,16 +1,31 @@
 import {useEffect} from 'react'
 
+const UNIDENTIFIED_KEYS = ['Unidentified', 'Process']
+
 const useKeyPress = (callback, {target, onChange}) => {
-  const events = []
   return useEffect(() => {
     const element = target?.current
-    if (element) {
-      events.push(element.addEventListener('keydown', callback))
+    if (!element) return
+
+    const handleKeyDown = event => {
+      if (UNIDENTIFIED_KEYS.includes(event.key)) return
+      if (event.key.length === 1) {
+        event.preventDefault()
+      }
+      callback(event)
     }
+
+    const handleInput = event => {
+      if (!event.data) return
+      // eslint-disable-next-line n/no-callback-literal
+      callback({key: event.data, preventDefault: () => {}})
+    }
+
+    element.addEventListener('keydown', handleKeyDown)
+    element.addEventListener('input', handleInput)
     return () => {
-      events.forEach(event => {
-        if (element) element.removeEventListener('keydown', callback)
-      })
+      element.removeEventListener('keydown', handleKeyDown)
+      element.removeEventListener('input', handleInput)
     }
   }, [target, callback, onChange]) // eslint-disable-line react-hooks/exhaustive-deps
 }

--- a/components/atom/pinInput/test/index.test.js
+++ b/components/atom/pinInput/test/index.test.js
@@ -1570,6 +1570,74 @@ describe(json.name, () => {
         expect(focusPosition).to.equal(initialFocusPosition + 1)
         expect(newInnerValue.filter(Boolean).join('')).to.equal(args.value)
       })
+
+      it("given an 'Unidentified' key event (mobile virtual keyboard) should NOT change anything", () => {
+        // Given
+        const args = {value: '123456'}
+        const eventArgs = {key: 'Unidentified'}
+
+        // When
+        const hook = setupReducerEnvironment(args)
+        let [store, dispatch] = hook.result.current
+
+        const {focusPosition: initialFocusPosition, innerValue} = store
+
+        // Then
+        expect(initialFocusPosition).to.equal(0)
+        expect(innerValue.filter(Boolean).join('')).to.equal(args.value)
+
+        // And
+        // Given
+        const onChange = () => null
+        const keyboardEvent = new KeyboardEvent('keydown', {...eventArgs})
+
+        // When
+        dispatch(atomPinInputActions.setKey({event: keyboardEvent, onChange}))
+        hook.rerender()
+
+        // Then
+        store = hook.result.current[0]
+        const focusPosition = store.focusPosition
+        const newInnerValue = store.innerValue
+        expect(focusPosition).to.equal(initialFocusPosition)
+        expect(newInnerValue.filter(Boolean).join('')).to.equal(args.value)
+      })
+
+      it('given a synthetic input event (mobile fallback) with a valid char changes innerValue and increments focusPosition', () => {
+        // Given
+        const args = {value: '123456'}
+
+        // When
+        const hook = setupReducerEnvironment(args)
+        let [store, dispatch] = hook.result.current
+
+        const {focusPosition: initialFocusPosition, innerValue} = store
+
+        // Then
+        expect(initialFocusPosition).to.equal(0)
+        expect(innerValue.filter(Boolean).join('')).to.equal(args.value)
+
+        // And
+        // Given
+        const onChange = () => null
+        const syntheticEvent = {key: '9', preventDefault: () => {}}
+
+        // When
+        dispatch(atomPinInputActions.setKey({event: syntheticEvent, onChange}))
+        hook.rerender()
+
+        // Then
+        store = hook.result.current[0]
+        const focusPosition = store.focusPosition
+        const newInnerValue = store.innerValue
+        expect(focusPosition).to.equal(initialFocusPosition + 1)
+        expect(newInnerValue.filter(Boolean).join('')).to.equal(
+          args.value
+            .split('')
+            .map((value, index) => (index === initialFocusPosition ? '9' : value))
+            .join('')
+        )
+      })
     })
 
     describe('atomPinInputActions', () => {


### PR DESCRIPTION
### Problem

Some mobile users were unable to type any character into the PinInput component when using a virtual (on-screen) keyboard.

The root cause was that the component relied exclusively on `keydown` events to capture input. Most Android virtual keyboards fire `keydown` with `event.key = "Unidentified"` (or `"Process"`) instead of the actual character. In the reducer, `"Unidentified".length > 1` caused the event to enter the special-key `switch` block, where it fell through a `default: break` — silently dropping the input. Because the `<input>` elements are controlled components and their React `onChange` was a no-op, the native browser update was also discarded on every re-render.

### Solution

Added an `input` event listener alongside the existing `keydown` listener in `useKeyPress`:

- **`keydown`**: now skips keys reported as `"Unidentified"` or `"Process"` and lets the `input` event handle them. For normal printable characters on desktop, `preventDefault()` is called to suppress the subsequent `input` event and avoid double-processing.
- **`input`**: fires when `keydown` didn't process the character (mobile path). Passes a synthetic `{ key: event.data }` object to the existing callback, which flows through the reducer's existing single-character validation logic without any reducer changes.

Also fixed a pre-existing bug in `useKeyPress` where the `events` array was accumulating `undefined` values (the return value of `addEventListener`) and was never used for proper cleanup.

### Files changed

- `components/atom/pinInput/src/hooks/useKeyPress.js` — dual `keydown`/`input` listener with guards
- `components/atom/pinInput/test/index.test.js` — two new reducer tests covering the `"Unidentified"` key path and the synthetic mobile input event path