### PR TITLE
fix(components/molecule/accordion): fix accordion in iOS Safari 26.4

### DIFF
--- a/components/molecule/accordion/src/AccordionItemPanel.js
+++ b/components/molecule/accordion/src/AccordionItemPanel.js
@@ -52,27 +52,48 @@ const AccordionItemPanel = forwardRef(
         className={accordionItemPanelClassName}
         aria-disabled={disabled}
         style={{
-          overflowY: height > maxHeight && maxHeight !== 0 ? 'scroll' : 'hidden',
-          transition: `max-height ${animationDuration}ms ${
+          // grid-template-rows animation is layout-safe: siblings are pushed down
+          // correctly in all browsers including iOS Safari ≥16.4.
+          // max-height animation was replaced because it requires transform/will-change
+          // hacks to avoid Safari repaint corruption, and those hacks break document flow.
+          display: 'grid',
+          gridTemplateRows: values.includes(value) ? '1fr' : '0fr',
+          transition: `grid-template-rows ${animationDuration}ms ${
             values.includes(value) ? 'ease-out' : 'ease-in'
           }, opacity 0s linear ${values.includes(value) ? 0 : animationDuration}ms, border-top-width 0s linear ${
             values.includes(value) ? 0 : animationDuration
-          }ms`,
-          ...(values.includes(value) && {
-            maxHeight: maxHeight === 0 ? height : maxHeight
-          })
+          }ms`
         }}
         {...props}
       >
         <Poly
           as={as}
+          // overflow:hidden + min-height:0 must be on the direct grid child so that
+          // grid-template-rows:0fr can collapse it to zero height. These cannot live
+          // inside the !isFragment spread because isFragment is a function (always truthy),
+          // making !isFragment always false — the spread never executes.
+          style={{overflow: 'hidden', minHeight: 0}}
           {...{
             ...(!isFragment && {
               className: `${BASE_CLASS_ITEM_PANEL_CONTENT}Wrapper`
             })
           }}
         >
-          <div className={`${BASE_CLASS_ITEM_PANEL_CONTENT}WrapperRef`} ref={contentRef}>
+          <div
+            className={`${BASE_CLASS_ITEM_PANEL_CONTENT}WrapperRef`}
+            ref={contentRef}
+            style={{
+              // min-height: 0 is required for grid-template-rows: 0fr to collapse the child to zero
+              overflow: 'hidden',
+              minHeight: 0,
+              // maxHeight prop caps panel height and enables scroll — applied here (not on
+              // the outer grid wrapper) so it constrains content without affecting the animation
+              ...(maxHeight !== 0 && {
+                maxHeight,
+                overflowY: height > maxHeight ? 'scroll' : 'hidden'
+              })
+            }}
+          >
             {inject(children, [
               {
                 props: {

--- a/components/molecule/accordion/src/AccordionItemPanel.js
+++ b/components/molecule/accordion/src/AccordionItemPanel.js
@@ -72,7 +72,13 @@ const AccordionItemPanel = forwardRef(
           // grid-template-rows:0fr can collapse it to zero height. These cannot live
           // inside the !isFragment spread because isFragment is a function (always truthy),
           // making !isFragment always false — the spread never executes.
-          style={{overflow: 'hidden', minHeight: 0}}
+          style={{
+            // overflow must be 'hidden' while collapsed so 0fr clips the content.
+            // Once expanded, switch to 'visible' so popovers/dropdowns inside the
+            // panel can overflow outside its bounds (e.g. make/model picker on desktop).
+            overflow: values.includes(value) ? 'visible' : 'hidden',
+            minHeight: 0
+          }}
           {...{
             ...(!isFragment && {
               className: `${BASE_CLASS_ITEM_PANEL_CONTENT}Wrapper`
@@ -83,8 +89,7 @@ const AccordionItemPanel = forwardRef(
             className={`${BASE_CLASS_ITEM_PANEL_CONTENT}WrapperRef`}
             ref={contentRef}
             style={{
-              // min-height: 0 is required for grid-template-rows: 0fr to collapse the child to zero
-              overflow: 'hidden',
+              overflow: values.includes(value) ? 'visible' : 'hidden',
               minHeight: 0,
               // maxHeight prop caps panel height and enables scroll — applied here (not on
               // the outer grid wrapper) so it constrains content without affecting the animation

--- a/components/molecule/accordion/src/styles/index.scss
+++ b/components/molecule/accordion/src/styles/index.scss
@@ -174,10 +174,10 @@ $base-class-item-panel: '#{$base-class-item}Panel';
 }
 
 #{$base-class-item-panel} {
-  overflow: hidden;
+  // overflow and collapse are handled by grid-template-rows animation (JS inline style).
+  // overflow: hidden lives on the inner WrapperRef child (required for 0fr collapse to work).
 
   &--collapsed {
-    max-height: 0;
     opacity: 0;
     border-bottom: 0;
   }


### PR DESCRIPTION
## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
<!-- #### `🔍 Show` -->
`❓ Ask` 

<!-- https://github.com/SUI-Components/sui-components/issues -->

### Description, Motivation and Context
Fix accordion rendering issues in **iOS Safari ≥26.4** by replacing `max-height` animations with a grid-based approach (`grid-template-rows: 0fr → 1fr`).

This avoids known WebKit repaint bugs with `overflow: hidden` inside scroll containers and ensures correct layout flow (siblings are pushed down properly).

Adds required constraints (`min-height: 0` and `overflow: hidden`) to allow proper collapsing behavior.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
**Before** 

https://github.com/user-attachments/assets/fc04fbc1-c09e-4854-b566-2e46e2fb55a4

https://github.com/user-attachments/assets/232f6a15-daab-4477-aa17-7a99051a5a03

https://github.com/user-attachments/assets/00ccc924-a758-4ff4-8182-da707ef419c0

**After**

https://github.com/user-attachments/assets/67903fdc-6012-4f76-ae75-02fbe6cf3ea9

https://github.com/user-attachments/assets/ac6e2abb-ebb3-4c4c-b820-7505f1fff40b

https://github.com/user-attachments/assets/d418745e-e404-4f7e-8832-7572d0e51f97



