### PR TITLE
refactor(components/atom/icon): simplify ArticleDesign by removing unused state and RadioButtonGroup

### DIFF
--- a/components/atom/icon/demo/articles/ArticleDesign.js
+++ b/components/atom/icon/demo/articles/ArticleDesign.js
@@ -1,26 +1,14 @@
-import {Fragment, useState} from 'react'
+import {Fragment} from 'react'
 import {IconBrandGithub, IconBrandGithubFilled} from '@tabler/icons-react'
 
 import PropTypes from 'prop-types'
 
-import {
-  AntDesignIcon,
-  Article,
-  Cell,
-  Code,
-  Grid,
-  H2,
-  Label,
-  Paragraph,
-  RadioButton,
-  RadioButtonGroup
-} from '@s-ui/documentation-library'
+import {Article, Cell, Code, Grid, H2, Label, Paragraph} from '@s-ui/documentation-library'
 
 import AtomIcon, {ATOM_ICON_COLORS, ATOM_ICON_DESIGNS} from '../../src/index.js'
-import {flexCenteredStyle, ICONS} from '../settings.js'
+import {flexCenteredStyle} from '../settings.js'
 
 const ArticleDesign = ({className}) => {
-  const [selectedIcon, setIcon] = useState(Object.values(ICONS)[0])
   return (
     <Article className={className}>
       <H2>Design</H2>
@@ -32,22 +20,6 @@ const ArticleDesign = ({className}) => {
         <Code>design</Code> prop.
       </Paragraph>
       –––
-      <br />
-      <br />
-      <RadioButtonGroup onChange={(event, value) => setIcon(value)} value={selectedIcon}>
-        {Object.values(ICONS).map(({name, label}, index) => (
-          <RadioButton
-            key={index}
-            value={{name, label}}
-            aria-label={label}
-            label={
-              <AtomIcon>
-                <AntDesignIcon icon={name} style={{color: 'currentColor'}} />
-              </AtomIcon>
-            }
-          />
-        ))}
-      </RadioButtonGroup>
       <br />
       <br />
       <Grid cols={9} gutter={[8, 8]}>


### PR DESCRIPTION
## Atom/Icon
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
<!-- #### `🔍 Show` -->
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
